### PR TITLE
Adding requireValue

### DIFF
--- a/packages/signals/lib/src/future_signal.dart
+++ b/packages/signals/lib/src/future_signal.dart
@@ -109,6 +109,15 @@ class FutureSignal<T> implements ReadonlySignal<T?> {
   /// Returns true if the future signal is loading
   bool get isLoading => _state.peek().$1 == _FutureState.loading;
 
+  /// Returns the value of the signal or throws an error if not a value
+  /// This method uses peek() to get the value and will not subscribe to the
+  /// signal.
+  T get requireValue {
+    final (state, val, err) = _state.peek();
+    if (state == _FutureState.value) return val as T;
+    throw err ?? {};
+  }
+
   /// Returns the value of the signal or null if not a value
   E map<E>({
     required FutureSignalValueBuilder<E, T> value,

--- a/packages/signals/lib/src/stream_signal.dart
+++ b/packages/signals/lib/src/stream_signal.dart
@@ -107,6 +107,15 @@ class StreamSignal<T> implements ReadonlySignal<T?> {
   /// Returns true if the future signal is loading
   bool get isLoading => _state.peek().$1 == _StreamState.loading;
 
+  /// Returns the value of the signal or throws an error if not a value
+  /// This method uses peek() to get the value and will not subscribe to the
+  /// signal.
+  T get requireValue {
+    final (state, val, err) = _state.peek();
+    if (state == _StreamState.value) return val as T;
+    throw err ?? {};
+  }
+
   /// Returns the value of the signal or null if not a value
   E map<E>({
     required StreamSignalValueBuilder<E, T> value,

--- a/website/src/content/docs/reference/future.md
+++ b/website/src/content/docs/reference/future.md
@@ -132,3 +132,14 @@ final mapped = s.maybeMap(
     orElse: () => 'loading',
 );
 ```
+
+## .requireValue
+
+The `requireValue` method returns the value of the future if it completed successfully or throws an error if it completed with an error.
+
+This uses `peek` internally and will not subscribe to updates if used inside an `effect` or `computed`.
+
+```dart
+final s = futureSignal(Future(() => 1));
+final value = s.requireValue(); // 1
+```

--- a/website/src/content/docs/reference/stream.md
+++ b/website/src/content/docs/reference/stream.md
@@ -151,3 +151,19 @@ final mapped = s.maybeMap(
     orElse: () => 'loading',
 );
 ```
+
+## .requireValue
+
+The `requireValue` method returns the value of the stream if it completed successfully or throws an error if it completed with an error.
+
+This uses `peek` internally and will not subscribe to updates if used inside an `effect` or `computed`.
+
+```dart
+final s = streamSignal(() async* {
+    yield 1;
+    yield 2;
+    yield 3;
+});
+final value = s.requireValue(); // 1
+```
+


### PR DESCRIPTION
* Adding `requireValue` to `FutureSignal` and `StreamSignal`

This can allow for requiring the value of the correct type and throw an error if not ready or has error