### PR TITLE
Rename Connect `to` `from`

### DIFF
--- a/examples/rxdart_example/web/main.dart
+++ b/examples/rxdart_example/web/main.dart
@@ -42,7 +42,7 @@ void main() {
       .map((_) => konami.value = true)
       .startWith(false);
 
-  // both forms are equals:
   // connect(konami).from(konamiStream);
+  // or
   connect(konami) << konamiStream;
 }

--- a/examples/rxdart_example/web/main.dart
+++ b/examples/rxdart_example/web/main.dart
@@ -42,5 +42,7 @@ void main() {
       .map((_) => konami.value = true)
       .startWith(false);
 
-  connect(konami).from(konamiStream);
+  // both form are equals
+  // connect(konami).from(konamiStream);
+  connect(konami) << konamiStream;
 }

--- a/examples/rxdart_example/web/main.dart
+++ b/examples/rxdart_example/web/main.dart
@@ -1,4 +1,5 @@
 import 'dart:html';
+
 import 'package:collection/collection.dart';
 import 'package:rxdart/rxdart.dart';
 import 'package:signals/signals.dart';
@@ -41,5 +42,5 @@ void main() {
       .map((_) => konami.value = true)
       .startWith(false);
 
-  connect(konami).to(konamiStream);
+  connect(konami).from(konamiStream);
 }

--- a/examples/rxdart_example/web/main.dart
+++ b/examples/rxdart_example/web/main.dart
@@ -42,5 +42,7 @@ void main() {
       .map((_) => konami.value = true)
       .startWith(false);
 
-  connect(konami).from(konamiStream);
+  // both forms are equals:
+  // connect(konami).from(konamiStream);
+  connect(konami) << konamiStream;
 }

--- a/packages/signals/lib/src/connect.dart
+++ b/packages/signals/lib/src/connect.dart
@@ -2,13 +2,13 @@ import 'dart:async';
 
 import 'signals.dart';
 
-/// Connects a [MutableSignal] to a [Stream].
+/// Connects a [Stream] to a [MutableSignal].
 class Connect<T> {
   Connect(this.signal);
   final MutableSignal<T> signal;
   final Map<int, StreamSubscription> _subscriptions = {};
 
-  /// Connects a [MutableSignal] to a [Stream].
+  /// Connects a [Stream] to a [MutableSignal].
   ///
   /// ```dart
   /// final counter = signal(0);
@@ -17,24 +17,24 @@ class Connect<T> {
   /// final s1 = Stream.value(1);
   /// final s2 = Stream.value(2);
   ///
-  /// c.to(s1).to(s2);
+  /// c.from(s1).from(s2);
   ///
   /// c.dispose();
   /// ```
-  Connect<T> to(
-    Stream<T> stream, {
+  Connect<T> from(
+    Stream<T> source, {
     bool? cancelOnError,
   }) {
-    final subscription = stream.listen(
+    final subscription = source.listen(
       (event) {
         signal.value = event;
       },
       onDone: () {
-        _subscriptions.removeWhere((key, value) => key == stream.hashCode);
+        _subscriptions.removeWhere((key, value) => key == source.hashCode);
       },
       cancelOnError: cancelOnError,
     );
-    _subscriptions[stream.hashCode] = subscription;
+    _subscriptions[source.hashCode] = subscription;
     return this;
   }
 

--- a/packages/signals/lib/src/connect.dart
+++ b/packages/signals/lib/src/connect.dart
@@ -38,7 +38,7 @@ class Connect<T> {
     return this;
   }
 
-  /// Synonym for `from()`
+  /// Synonym for `from(Stream<T> source)`
   Connect<T> operator <<(Stream<T> source) => from(source);
 
   /// Cancels all subscriptions.

--- a/packages/signals/lib/src/connect.dart
+++ b/packages/signals/lib/src/connect.dart
@@ -38,6 +38,9 @@ class Connect<T> {
     return this;
   }
 
+  /// Synonym for `from()`
+  Connect<T> operator <<(Stream<T> source) => from(source);
+
   /// Cancels all subscriptions.
   void dispose() {
     for (final subscription in _subscriptions.values) {

--- a/website/src/content/docs/examples/dart-operators-example.md
+++ b/website/src/content/docs/examples/dart-operators-example.md
@@ -1,6 +1,6 @@
 ---
-title: Dart Pipe Example
-description: Dart example using pipe
+title: Dart Operators Example
+description: Use of Operators as shorthand
 ---
 
 ```dart
@@ -29,6 +29,10 @@ void main() {
   final s6 = s4 | s5;
 
   assert(deepEq(s6, ['s', 'i', 'g', 'n', 'a', 'l']));
+  
+  // `Connect()` a Stream to Signal using operator
+  final x = Stream.fromIterable([1,2,3]);
+  final counter = connect(signal(0)) << x;
 }
 
 ```

--- a/website/src/content/docs/reference/connect.md
+++ b/website/src/content/docs/reference/connect.md
@@ -39,6 +39,8 @@ final s1 = Stream.value(1);
 final s2 = Stream.value(2);
 
 c.from(s1).from(s2);
+// or
+c << s1 << s2
 
 c.dispose(); // This will cancel all subscriptions
 ```

--- a/website/src/content/docs/reference/connect.md
+++ b/website/src/content/docs/reference/connect.md
@@ -6,6 +6,7 @@ description: Connect a signal to a set of streams
 ## connect
 
 Start with a signal and then use the `connect` method to create a connector.
+Streams will feed Signal value.
 
 ```dart
 final s = signal(0);
@@ -23,7 +24,7 @@ final c = connect(s);
 final s1 = Stream.value(1);
 final s2 = Stream.value(2);
 
-c.to(s1).to(s2); // These can be chained
+c.from(s1).from(s2); // These can be chained
 ```
 
 ### dispose
@@ -37,7 +38,7 @@ final c = connect(s);
 final s1 = Stream.value(1);
 final s2 = Stream.value(2);
 
-c.to(s1).to(s2);
+c.from(s1).from(s2);
 
 c.dispose(); // This will cancel all subscriptions
 ```


### PR DESCRIPTION
While reading the Konami exercice I read 

`connect(konami).to(konamiStream);`

My first understanding was that `connect` makes the signal push values to the stream which is not the case. 
The name and order of method lead to that.

Here's a tentative to clarify the reading by changing the verb since we can't reverse the order.

`connect(konami).from(konamiStream).from(...);`