### PR TITLE
Timer and Initial value in StreamSignal

### DIFF
--- a/examples/dart_examples/bin/pipes.dart
+++ b/examples/dart_examples/bin/pipes.dart
@@ -3,25 +3,22 @@ import 'dart:math';
 import 'package:signals/signals.dart';
 
 void main() {
-  /*
-  Signal<bool> from a periodic Stream
-   */
-  final timer =
-      Stream.periodic(const Duration(milliseconds: 2000), (ms) {}).toSignal();
+  /// Recurring event
+  final timer = Duration(milliseconds: 800).toSignal();
 
   const poolSize = 5;
 
   final candidate = signal(0);
 
-  /*
-  Signal<int> from an Iterable
-   */
+  /// Signal<int> from an Iterable
   final source = List.generate(poolSize, (index) => generate()).toSignal();
 
   /// Each time the timer move on we take the first element of the list
   effect(() {
     // Subscribe to timer event
-    timer.value;
+    // timer.value;
+    // or
+    timer();
 
     // We use peek to avoid subscription to source
     final [head, ...tail] = source.peek();

--- a/examples/dart_examples/bin/timer.dart
+++ b/examples/dart_examples/bin/timer.dart
@@ -1,0 +1,11 @@
+import 'package:signals/signals.dart';
+
+main() {
+  final timer = Duration(milliseconds: 800).toSignal(cancelOnError: true);
+
+  effect(() {
+    final on = timer();
+
+    print(on);
+  });
+}

--- a/examples/dart_examples/bin/timer.dart
+++ b/examples/dart_examples/bin/timer.dart
@@ -1,11 +1,15 @@
 import 'package:signals/signals.dart';
 
 main() {
-  final timer = Duration(milliseconds: 800).toSignal(cancelOnError: true);
+  final timer = Duration(milliseconds: 2000).toSignal(cancelOnError: true);
 
   effect(() {
     final on = timer();
 
-    print(on);
+    if (on != null) {
+      print(on);
+      var dateTime = DateTime.fromMillisecondsSinceEpoch(on.millis);
+      print("${dateTime.hour}:${dateTime.minute}:${dateTime.second}");
+    }
   });
 }

--- a/examples/dart_examples/pubspec.yaml
+++ b/examples/dart_examples/pubspec.yaml
@@ -7,6 +7,7 @@ environment:
   sdk: ^3.1.0
 
 dependencies:
+  intl:
   collection:
   signals:
     path: ../../packages/signals

--- a/packages/signals/CHANGELOG.md
+++ b/packages/signals/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 1.4.2
+
+- Adding `Timer` to emit `TimerEvent`
+- Adding `initial` to `StreamSignal` to skip loading state and avoid emit null value
+
+## 1.4.1
+
+- Adding `sorted` to `ListSignal` that returns new list with sorted values (does not mutate original list)
+
 ## 1.4.0
 
 - Deprecating `MutableSignal` in favor of `Signal` (abstract class)

--- a/packages/signals/lib/signals.dart
+++ b/packages/signals/lib/signals.dart
@@ -1,5 +1,19 @@
 library signals;
 
+export 'src/connect.dart' show connect, Connect;
+export 'src/extensions/future.dart';
+export 'src/extensions/iterable.dart';
+export 'src/extensions/iterable.dart';
+export 'src/extensions/iterable.dart';
+export 'src/extensions/list.dart';
+export 'src/extensions/map.dart';
+export 'src/extensions/set.dart';
+export 'src/extensions/stream.dart';
+export 'src/future_signal.dart' show futureSignal, FutureSignal;
+export 'src/iterable_signal.dart' show iterableSignal, IterableSignal;
+export 'src/list_signal.dart' show listSignal, ListSignal;
+export 'src/map_signal.dart' show mapSignal, MapSignal;
+export 'src/set_signal.dart' show setSignal, SetSignal;
 export 'src/signals.dart'
     show
         signal,
@@ -13,16 +27,5 @@ export 'src/signals.dart'
         ValueSignal,
         MutableSignal,
         ReadonlySignal;
-export 'src/future_signal.dart' show futureSignal, FutureSignal;
-export 'src/stream_signal.dart' show streamSignal, StreamSignal;
-export 'src/list_signal.dart' show listSignal, ListSignal;
-export 'src/map_signal.dart' show mapSignal, MapSignal;
-export 'src/set_signal.dart' show setSignal, SetSignal;
-export 'src/iterable_signal.dart' show iterableSignal, IterableSignal;
-export 'src/connect.dart' show connect, Connect;
-export 'src/extensions/stream.dart';
-export 'src/extensions/future.dart';
-export 'src/extensions/list.dart';
-export 'src/extensions/map.dart';
-export 'src/extensions/set.dart';
-export 'src/extensions/iterable.dart';
+export 'src/stream_signal.dart' show streamSignal, StreamSignaldartldart;
+export 'src/utils/timer.dart' show Timer, TimerExtension;

--- a/packages/signals/lib/src/stream_signal.dart
+++ b/packages/signals/lib/src/stream_signal.dart
@@ -36,9 +36,10 @@ class StreamSignal<T> implements ReadonlySignal<T?> {
   final bool fireImmediately;
 
   // Before first data is collected, state is in [_StreamState.loading]
-  Signal<(_StreamState, T?, Object?)> _state;
+  final Signal<(_StreamState, T?, Object?)> _state;
 
   /// Creates a [StreamSignal] that wraps a [Stream]
+  /// Defining an `initial` value will skip the loading state
   StreamSignal(
     this._compute, {
     this.cancelOnError,

--- a/packages/signals/lib/src/stream_signal.dart
+++ b/packages/signals/lib/src/stream_signal.dart
@@ -35,24 +35,31 @@ class StreamSignal<T> implements ReadonlySignal<T?> {
   /// If true then the future will be called immediately
   final bool fireImmediately;
 
+  // Before first data is collected, state is in [_StreamState.loading]
+  Signal<(_StreamState, T?, Object?)> _state;
+
   /// Creates a [StreamSignal] that wraps a [Stream]
   StreamSignal(
     this._compute, {
     this.cancelOnError,
     this.fireImmediately = false,
     this.debugLabel,
-  }) {
+    T? initial,
+  }) : _state = signal<(_StreamState, T?, Object?)>((
+          initial != null ? _StreamState.value : _StreamState.loading,
+          initial,
+          null,
+        )) {
     _stale = true;
+
     if (fireImmediately) _execute();
   }
 
+  // User defined function
   final Stream<T> Function() _compute;
+
   bool _stale = false;
-  final _state = signal<(_StreamState, T?, Object?)>((
-    _StreamState.loading,
-    null,
-    null,
-  ));
+
   StreamSubscription<T>? _subscription;
 
   /// Resets the signal by calling the [Stream] again

--- a/packages/signals/lib/src/utils/timer.dart
+++ b/packages/signals/lib/src/utils/timer.dart
@@ -1,0 +1,35 @@
+import '../stream_signal.dart';
+
+/// Time event to react to
+typedef TimerEvent = ({int iteration, int millis});
+
+/// Emit recurring [TimerEvent] aka [StreamSignal]
+class Timer extends StreamSignal<TimerEvent> {
+  // Trigger an [TimerEvent] every duration
+  final Duration every;
+
+  Timer({
+    required this.every,
+    super.cancelOnError,
+    super.fireImmediately = false,
+    super.debugLabel = 'Timer',
+  }) : super(() => Stream<TimerEvent>.periodic(every, (c) => _emit(c + 1)),
+            initial: _emit(0));
+
+  static TimerEvent _emit(int count) =>
+      (iteration: count, millis: DateTime.now().millisecondsSinceEpoch);
+}
+
+/// Expose Duration as a [Timer]
+extension TimerExtension on Duration {
+  Timer toSignal(
+          {String? debugLabel,
+          bool fireImmediately = false,
+          bool? cancelOnError}) =>
+      Timer(
+        every: this,
+        debugLabel: debugLabel,
+        fireImmediately: fireImmediately,
+        cancelOnError: cancelOnError,
+      );
+}

--- a/website/src/content/docs/examples/dart-pipe-example.md
+++ b/website/src/content/docs/examples/dart-pipe-example.md
@@ -9,25 +9,22 @@ import 'dart:math';
 import 'package:signals/signals.dart';
 
 void main() {
-  /*
-  Signal<bool> from a periodic Stream
-   */
-  final timer =
-      Stream.periodic(const Duration(milliseconds: 2000), (ms) {}).toSignal();
+  /// Recurring event
+  final timer = Duration(milliseconds: 800).toSignal();
 
   const poolSize = 5;
 
   final candidate = signal(0);
 
-  /*
-  Signal<int> from an Iterable
-   */
+  /// Signal<int> from an Iterable
   final source = List.generate(poolSize, (index) => generate()).toSignal();
 
   /// Each time the timer move on we take the first element of the list
   effect(() {
     // Subscribe to timer event
-    timer.value;
+    // timer.value;
+    // or
+    timer();
 
     // We use peek to avoid subscription to source
     final [head, ...tail] = source.peek();
@@ -58,4 +55,5 @@ void main() {
 final rdm = Random();
 
 int generate() => rdm.nextInt(9999);
+
 ```


### PR DESCRIPTION
Adding a timer utils to works with TimeEvent.

Updated StreamSignal with option of `T? initial` to avoid emit a first
`null` value of loading status.

Please look at `timer.dart` for an exemple.

Help required to see if we can do better than null-check:

``` dart
final on = timer();
if (on != null) {
 ...
}
```

Dev branch required :)
