### PR TITLE
Fix memory leak in Connect.from()

### DIFF
--- a/packages/signals/lib/src/connect.dart
+++ b/packages/signals/lib/src/connect.dart
@@ -25,6 +25,10 @@ class Connect<T> {
     Stream<T> source, {
     bool? cancelOnError,
   }) {
+    // stop multiple subscriptions to the same stream
+    if (_subscriptions.containsKey(source.hashCode)) {
+      return this;
+    }
     final subscription = source.listen(
       (event) {
         signal.value = event;


### PR DESCRIPTION
This line overwrites the old subscription so you'd lose reference to it and therefore cannot cancel it.
```js
_subscriptions[source.hashCode] = subscription;
```

Fix my stopping multiple subscriptions to the same stream.