### PR TITLE
Named Signals

### DIFF
--- a/examples/dart_examples/bin/operators.dart
+++ b/examples/dart_examples/bin/operators.dart
@@ -4,9 +4,11 @@ import 'package:signals/signals.dart';
 /// Operators on Signals Collection
 /// Combine Data Flow
 void main() {
+  SignalsObserver.instance = LoggingSignalsObserver();
+
   final deepEq = const DeepCollectionEquality().equals;
 
-  final s0 = [0, 1, 2].toSignal();
+  final s0 = [0, 1, 2].toSignal('Initial');
 
   // s1 fork s0 and add new values
   final s1 = s0 & [3, 4, 5];
@@ -19,8 +21,8 @@ void main() {
 
   assert(deepEq(s0, [0, 1, 2, 3, 4, 5]));
 
-  final s4 = ['s', 'i', 'g'].toSignal();
-  final s5 = ['n', 'a', 'l'].toSignal();
+  final s4 = ['s', 'i', 'g'].toSignal('First part');
+  final s5 = ['n', 'a', 'l'].toSignal('Second part');
 
   // s6 is a new signal
   final s6 = s4 | s5;

--- a/examples/dart_examples/bin/pipes.dart
+++ b/examples/dart_examples/bin/pipes.dart
@@ -3,15 +3,18 @@ import 'dart:math';
 import 'package:signals/signals.dart';
 
 void main() {
+  SignalsObserver.instance = LoggingSignalsObserver();
+
   /// Recurring event
-  final timer = Duration(milliseconds: 800).toSignal();
+  final timer = TimerSignal(every: Duration(milliseconds: 800));
 
   const poolSize = 5;
 
   final candidate = signal(0);
 
   /// Signal<int> from an Iterable
-  final source = List.generate(poolSize, (index) => generate()).toSignal();
+  final source =
+      List.generate(poolSize, (index) => generate()).toSignal('source');
 
   /// Each time the timer move on we take the first element of the list
   effect(() {
@@ -31,7 +34,7 @@ void main() {
   });
 
   /// Display selected [candidate]
-  effect(() => print("Qualified to ${candidate.value}"));
+  effect(() => print("Qualified to ${candidate.value}"), 'Selection completed');
 
   /// Effect on source => refill
   effect(() {
@@ -43,7 +46,7 @@ void main() {
 
       print("Complemented with ${source.last}: ${source.value}\n");
     }
-  });
+  }, 'Refill');
 }
 
 final rdm = Random();

--- a/examples/dart_examples/bin/sqlite.dart
+++ b/examples/dart_examples/bin/sqlite.dart
@@ -15,9 +15,11 @@ final migrations = SqliteMigrations()
   }));
 
 typedef TestData = ({int id, String data});
-final items = listSignal<TestData>([]);
+final items = listSignal<TestData>([], 'Data');
 
 void main() async {
+  SignalsObserver.instance = LoggingSignalsObserver();
+
   final db = SqliteDatabase(path: '${Directory.systemTemp.path}/test.db');
   await migrations.migrate(db);
 

--- a/examples/dart_examples/bin/timer.dart
+++ b/examples/dart_examples/bin/timer.dart
@@ -2,6 +2,7 @@ import 'package:signals/signals.dart';
 
 /// Trigger [TimerSignalEvent]
 main() {
+  SignalsObserver.instance = LoggingSignalsObserver();
   final timer = TimerSignal(every: Duration(seconds: 1));
 
   effect(() {

--- a/examples/flutter_counter/lib/main.dart
+++ b/examples/flutter_counter/lib/main.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:signals/signals_flutter.dart';
 
-final brightness = signal(Brightness.light, debugLabel: 'Brightness');
+final brightness = signal(Brightness.light, 'Brightness');
 final isDark = computed(
   () => brightness.value == Brightness.dark,
-  debugLabel: 'Is Dark',
+  'Is Dark',
 );
 final themeMode = computed(
   () {
@@ -14,7 +14,7 @@ final themeMode = computed(
       return ThemeMode.light;
     }
   },
-  debugLabel: 'Theme Mode',
+  'Theme Mode',
 );
 
 void main() {
@@ -62,7 +62,7 @@ class MyHomePage extends StatefulWidget {
 }
 
 class _MyHomePageState extends State<MyHomePage> {
-  final Signal<int> counter = signal(0, debugLabel: 'Counter');
+  final Signal<int> counter = signal(0, 'Counter');
 
   void _incrementCounter() {
     counter.value++;

--- a/examples/get_it_signals/lib/main.dart
+++ b/examples/get_it_signals/lib/main.dart
@@ -11,7 +11,7 @@ typedef User = ({int id, String name});
 
 class Auth {
   /// Current user signal
-  final currentUser = signal<User?>(null);
+  final currentUser = signal<User?>(null, 'User');
 
   /// Computed signal that only emits when the user is logged in / out
   late final isLoggedIn = computed(() => currentUser() != null);
@@ -32,19 +32,13 @@ class Auth {
   }
 
   // Dispose of the stream controller
-  void dispose() {
-    _authListener.dispose();
-  }
+  void dispose() => _authListener.dispose();
 
   /// Login with user data
-  void login(User data) {
-    _controller.add(data);
-  }
+  void login(User data) => _controller.add(data);
 
   /// Logout
-  void logout() {
-    _controller.add(null);
-  }
+  void logout() => _controller.add(null);
 }
 
 @visibleForTesting
@@ -131,14 +125,14 @@ class _MyAppState extends State<MyApp> {
   }
 }
 
-final brightness = signal(Brightness.light);
+final brightness = signal(Brightness.light, 'Brightness');
 final themeMode = computed(() {
   if (brightness() == Brightness.dark) {
     return ThemeMode.dark;
   } else {
     return ThemeMode.light;
   }
-});
+}, 'Theme switch');
 
 class DarkModeToggle extends StatelessWidget {
   const DarkModeToggle({super.key});

--- a/examples/html_todo_app/web/main.dart
+++ b/examples/html_todo_app/web/main.dart
@@ -1,4 +1,5 @@
 import 'dart:html';
+
 import 'package:signals/signals.dart';
 
 typedef Task = ({String title, bool completed});
@@ -10,7 +11,7 @@ void main() {
   final taskFilter = document.getElementById("taskFilter")!;
   final taskCounter = document.getElementById("taskCounter")!;
 
-  final tasks = <Task>[].toSignal();
+  final tasks = <Task>[].toSignal('Tasks');
   final filter = signal("all");
 
   final filteredTasks = computed(() {
@@ -23,7 +24,7 @@ void main() {
     } else {
       return currentTasks.where((task) => task.completed).toList();
     }
-  });
+  }, 'Filtered');
 
   final taskCount = computed(() {
     return tasks.length;
@@ -84,5 +85,5 @@ void main() {
     Active: ${activeTaskCount.value}, 
     Completed: ${completedTaskCount.value}
     ''';
-  });
+  }, 'Display');
 }

--- a/packages/signals/lib/src/core/observer.dart
+++ b/packages/signals/lib/src/core/observer.dart
@@ -15,22 +15,22 @@ abstract class SignalsObserver {
 class LoggingSignalsObserver extends SignalsObserver {
   @override
   void onComputedCreated(Computed instance) {
-    log('computed created: [${instance.globalId}|${instance.debugLabel}]');
+    log('computed created: [${instance.debugLabel}]');
   }
 
   @override
   void onComputedUpdated(Computed instance, value) {
-    log('computed updated: [${instance.globalId}|${instance.debugLabel}] => $value');
+    log('computed updated: [${instance.debugLabel}] => $value');
   }
 
   @override
   void onSignalCreated(Signal instance) {
-    log('signal created: [${instance.globalId}|${instance.debugLabel}] => ${instance.peek()}');
+    log('signal created: [${instance.debugLabel}] => ${instance.peek()}');
   }
 
   @override
   void onSignalUpdated(Signal instance, value) {
-    log('signal updated: [${instance.globalId}|${instance.debugLabel}] => $value');
+    log('signal updated: [${instance.debugLabel}] => $value');
   }
 
   // ignore: avoid_print

--- a/packages/signals/lib/src/core/signals.dart
+++ b/packages/signals/lib/src/core/signals.dart
@@ -191,7 +191,7 @@ typedef BatchCallback<T> = T Function();
 /// });
 /// // Now the callback completed and we'll trigger the effect.
 /// ```
-T batch<T>(BatchCallback<T> callback) {
+T batch<T>(BatchCallback<T> callback, [String debugLabel = '']) {
   if (_batchDepth > 0) {
     return callback();
   }
@@ -226,7 +226,7 @@ typedef UntrackedCallback<T> = T Function();
 /// 	effectCount.value = untracked(fn);
 /// });
 /// ```
-T untracked<T>(UntrackedCallback<T> callback) {
+T untracked<T>(UntrackedCallback<T> callback, [String debugLabel = '']) {
   if (_untrackedDepth > 0) {
     return callback();
   }

--- a/packages/signals/lib/src/extensions/future.dart
+++ b/packages/signals/lib/src/extensions/future.dart
@@ -14,7 +14,7 @@ extension SignalFutureUtils<T> on Future<T> {
   @Deprecated('Use [toSignalWithDefault] instead')
   FutureSignal<T> toSignal({
     Duration? timeout,
-    String? debugLabel,
+    String debugLabel = '',
     bool fireImmediately = false,
   }) {
     return FutureSignal<T>(
@@ -26,9 +26,9 @@ extension SignalFutureUtils<T> on Future<T> {
   }
 
   AsyncSignal<T> toSignalWithDefault(
-    T initialValue, {
-    String? debugLabel,
-  }) {
+    T initialValue, [
+    String debugLabel = '',
+  ]) {
     return AsyncSignal.fromFuture(
       () => this,
       initialValue: initialValue,
@@ -37,7 +37,7 @@ extension SignalFutureUtils<T> on Future<T> {
   }
 
   AsyncSignal<T?> toAsyncSignal({
-    String? debugLabel,
+    String debugLabel = '',
     T? initialValue,
   }) {
     return AsyncSignal.fromFuture(

--- a/packages/signals/lib/src/extensions/iterable.dart
+++ b/packages/signals/lib/src/extensions/iterable.dart
@@ -3,10 +3,10 @@ import '../value/iterable_signal.dart';
 /// Extension on future to provide helpful methods for signals
 extension SignalIterableUtils<T> on Iterable<T> {
   /// Convert an existing list to [IterableSignal]
-  IterableSignal<T> toSignal({String? debugLabel}) {
+  IterableSignal<T> toSignal([String debugLabel = '']) {
     return IterableSignal<T>(
       this,
-      debugLabel: debugLabel,
+      debugLabel,
     );
   }
 }

--- a/packages/signals/lib/src/extensions/list.dart
+++ b/packages/signals/lib/src/extensions/list.dart
@@ -3,10 +3,10 @@ import '../value/list_signal.dart';
 /// Extension on future to provide helpful methods for signals
 extension SignalListUtils<T> on List<T> {
   /// Convert an existing list to [ListSignal]
-  ListSignal<T> toSignal({String? debugLabel}) {
+  ListSignal<T> toSignal([String debugLabel = '']) {
     return ListSignal<T>(
       this,
-      debugLabel: debugLabel,
+      debugLabel,
     );
   }
 }

--- a/packages/signals/lib/src/extensions/map.dart
+++ b/packages/signals/lib/src/extensions/map.dart
@@ -3,10 +3,10 @@ import '../value/map_signal.dart';
 /// Extension on future to provide helpful methods for signals
 extension SignalMapUtils<K, V> on Map<K, V> {
   /// Convert an existing list to [MapSignal]
-  MapSignal<K, V> toSignal({String? debugLabel}) {
+  MapSignal<K, V> toSignal([String debugLabel = '']) {
     return MapSignal<K, V>(
       this,
-      debugLabel: debugLabel,
+      debugLabel,
     );
   }
 }

--- a/packages/signals/lib/src/extensions/set.dart
+++ b/packages/signals/lib/src/extensions/set.dart
@@ -3,10 +3,10 @@ import '../value/set_signal.dart';
 /// Extension on future to provide helpful methods for signals
 extension SignalSetUtils<T> on Set<T> {
   /// Convert an existing list to [SetSignal]
-  SetSignal<T> toSignal({String? debugLabel}) {
+  SetSignal<T> toSignal([String debugLabel = '']) {
     return SetSignal(
       this,
-      debugLabel: debugLabel,
+      debugLabel,
     );
   }
 }

--- a/packages/signals/lib/src/extensions/stream.dart
+++ b/packages/signals/lib/src/extensions/stream.dart
@@ -19,7 +19,7 @@ extension SignalStreamUtils<T> on Stream<T> {
   @Deprecated('Use [toSignalWithDefault] instead')
   StreamSignal<T> toSignal({
     bool? cancelOnError,
-    String? debugLabel,
+    String debugLabel = '',
     bool fireImmediately = false,
   }) {
     return StreamSignal<T>(
@@ -32,7 +32,7 @@ extension SignalStreamUtils<T> on Stream<T> {
 
   AsyncSignal<T> toSignalWithDefault(
     T initialValue, {
-    String? debugLabel,
+    String debugLabel = '',
     bool? cancelOnError,
   }) {
     return AsyncSignal.fromStream(
@@ -44,7 +44,7 @@ extension SignalStreamUtils<T> on Stream<T> {
   }
 
   AsyncSignal<T?> toAsyncSignal({
-    String? debugLabel,
+    String debugLabel = '',
     T? initialValue,
     bool? cancelOnError,
   }) {

--- a/packages/signals/lib/src/extensions/value_listenable.dart
+++ b/packages/signals/lib/src/extensions/value_listenable.dart
@@ -5,8 +5,8 @@ import '../core/signals.dart';
 /// Extension on [ValueListenable] to provide helpful methods for signals
 extension SignalValueListenableUtils<T> on ValueListenable<T> {
   /// Convert an existing [ValueListenable] to [ReadonlySignal]
-  ReadonlySignal<T> toSignal({String? debugLabel}) {
-    final s = signal<T>(value, debugLabel: debugLabel);
+  ReadonlySignal<T> toSignal([String debugLabel = '']) {
+    final s = signal<T>(value, debugLabel);
     addListener(() => s.value = value);
     return s;
   }

--- a/packages/signals/lib/src/extensions/value_notifier.dart
+++ b/packages/signals/lib/src/extensions/value_notifier.dart
@@ -5,8 +5,8 @@ import '../core/signals.dart';
 /// Extension on [ValueNotifier] to provide helpful methods for signals
 extension SignalValueNotifierUtils<T> on ValueNotifier<T> {
   /// Convert an existing [ValueNotifier] to [Signal]
-  Signal<T> toSignal({String? debugLabel}) {
-    final s = signal<T>(value, debugLabel: debugLabel);
+  Signal<T> toSignal([String debugLabel = '']) {
+    final s = signal<T>(value, debugLabel);
     addListener(() => s.value = value);
     s.subscribe((_) => value = s.value);
     return s;

--- a/packages/signals/lib/src/value/async_signal.dart
+++ b/packages/signals/lib/src/value/async_signal.dart
@@ -29,15 +29,15 @@ class AsyncSignal<T> implements ReadonlySignal<T> {
   bool get isCompleted => _completer.isCompleted;
 
   @override
-  final String? debugLabel;
+  final String debugLabel;
 
   /// Creates a [AsyncSignal] that wraps a [Stream]
   AsyncSignal.fromStream(
     Stream<T> Function() stream, {
     required T initialValue,
     bool? cancelOnError,
-    this.debugLabel,
-  }) : _result = signal<T>(initialValue, debugLabel: debugLabel) {
+    this.debugLabel = '',
+  }) : _result = signal<T>(initialValue, debugLabel) {
     _stream(() => stream(), cancelOnError: cancelOnError);
   }
 
@@ -45,8 +45,8 @@ class AsyncSignal<T> implements ReadonlySignal<T> {
   AsyncSignal.fromFuture(
     Future<T> Function() future, {
     required T initialValue,
-    this.debugLabel,
-  }) : _result = signal<T>(initialValue, debugLabel: debugLabel) {
+    this.debugLabel = '',
+  }) : _result = signal<T>(initialValue, debugLabel) {
     _future(() => future());
   }
 
@@ -217,7 +217,7 @@ class AsyncSignal<T> implements ReadonlySignal<T> {
 AsyncSignal<T> asyncSignalFromFuture<T>(
   Future<T> Function() future, {
   required T initialValue,
-  String? debugLabel,
+  String debugLabel = '',
 }) {
   return AsyncSignal.fromFuture(
     future,
@@ -230,7 +230,7 @@ AsyncSignal<T> asyncSignalFromStream<T>(
   Stream<T> Function() stream, {
   required T initialValue,
   bool? cancelOnError,
-  String? debugLabel,
+  String debugLabel = '',
 }) {
   return AsyncSignal.fromStream(
     stream,

--- a/packages/signals/lib/src/value/future_signal.dart
+++ b/packages/signals/lib/src/value/future_signal.dart
@@ -33,22 +33,23 @@ class FutureSignal<T> implements ReadonlySignal<T?> {
   /// If true then the future will be called immediately
   final bool fireImmediately;
 
+  /// Inner Signal
+  final Signal<(_FutureState, T?, Object?)> _state;
+
   /// Creates a [FutureSignal] that wraps a [Future]
   FutureSignal(
     this._compute, {
     this.timeout,
     this.fireImmediately = false,
-    this.debugLabel,
-  }) {
+    this.debugLabel = '',
+  }) : _state = signal<(_FutureState, T?, Object?)>((
+          _FutureState.loading,
+          null,
+          null,
+        ), debugLabel) {
     _stale = true;
     if (fireImmediately) _execute().ignore();
   }
-
-  final _state = signal<(_FutureState, T?, Object?)>((
-    _FutureState.loading,
-    null,
-    null,
-  ));
 
   final Future<T> Function() _compute;
   bool _stale = false;
@@ -221,7 +222,7 @@ class FutureSignal<T> implements ReadonlySignal<T?> {
   T? call() => value;
 
   @override
-  final String? debugLabel;
+  final String debugLabel;
 
   @override
   int get globalId => _state.globalId;
@@ -261,7 +262,7 @@ FutureSignal<T> futureSignal<T>(
   Future<T> Function() compute, {
   Duration? timeout,
   bool fireImmediately = false,
-  String? debugLabel,
+  String debugLabel = '',
 }) {
   return FutureSignal<T>(
     compute,

--- a/packages/signals/lib/src/value/iterable_signal.dart
+++ b/packages/signals/lib/src/value/iterable_signal.dart
@@ -4,7 +4,7 @@ import '../core/signals.dart';
 class IterableSignal<E> extends ValueSignal<Iterable<E>>
     implements Iterable<E> {
   /// Creates a [IterableSignal] with the given [value].
-  IterableSignal(super.value, {super.debugLabel});
+  IterableSignal(super.value, [super.debugLabel = '']);
 
   @override
   bool any(bool Function(E element) test) {
@@ -146,11 +146,11 @@ class IterableSignal<E> extends ValueSignal<Iterable<E>>
 
 /// Create an [IterableSignal] from [Iterable]
 IterableSignal<T> iterableSignal<T>(
-  Iterable<T> iterable, {
-  String? debugLabel,
-}) {
+  Iterable<T> iterable, [
+  String debugLabel = '',
+]) {
   return IterableSignal<T>(
     iterable,
-    debugLabel: debugLabel,
+    debugLabel,
   );
 }

--- a/packages/signals/lib/src/value/list_signal.dart
+++ b/packages/signals/lib/src/value/list_signal.dart
@@ -5,7 +5,7 @@ import '../core/signals.dart';
 /// A [Signal] that holds a [List].
 class ListSignal<E> extends ValueSignal<List<E>> implements List<E> {
   /// Creates a [ListSignal] with the given [value].
-  ListSignal(super.value, {super.debugLabel});
+  ListSignal(super.value, [super.debugLabel]);
 
   @override
   E get first => value.first;
@@ -364,11 +364,11 @@ class ListSignal<E> extends ValueSignal<List<E>> implements List<E> {
 
 /// Create an [ListSignal] from [List]
 ListSignal<T> listSignal<T>(
-  List<T> list, {
-  String? debugLabel,
-}) {
+  List<T> list, [
+  String debugLabel = '',
+]) {
   return ListSignal<T>(
     list,
-    debugLabel: debugLabel,
+    debugLabel,
   );
 }

--- a/packages/signals/lib/src/value/map_signal.dart
+++ b/packages/signals/lib/src/value/map_signal.dart
@@ -3,7 +3,7 @@ import '../core/signals.dart';
 /// A [Signal] that holds a [Map].
 class MapSignal<K, V> extends ValueSignal<Map<K, V>> implements Map<K, V> {
   /// Creates a [MapSignal] with the given [value].
-  MapSignal(super.value, {super.debugLabel});
+  MapSignal(super.value, [super.debugLabel]);
 
   @override
   V? operator [](Object? key) {
@@ -147,11 +147,11 @@ class MapSignal<K, V> extends ValueSignal<Map<K, V>> implements Map<K, V> {
 
 /// Create an [MapSignal] from [Map]
 MapSignal<K, V> mapSignal<K, V>(
-  Map<K, V> map, {
-  String? debugLabel,
-}) {
+  Map<K, V> map, [
+  String debugLabel = '',
+]) {
   return MapSignal<K, V>(
     map,
-    debugLabel: debugLabel,
+    debugLabel,
   );
 }

--- a/packages/signals/lib/src/value/set_signal.dart
+++ b/packages/signals/lib/src/value/set_signal.dart
@@ -3,7 +3,7 @@ import '../core/signals.dart';
 /// A [Signal] that holds a [Set].
 class SetSignal<E> extends ValueSignal<Set<E>> implements Set<E> {
   /// Creates a [SetSignal] with the given [value].
-  SetSignal(super.value, {super.debugLabel});
+  SetSignal(super.value, [super.debugLabel]);
 
   @override
   bool add(E value) {
@@ -253,11 +253,11 @@ class SetSignal<E> extends ValueSignal<Set<E>> implements Set<E> {
 
 /// Create an [SetSignal] from [Set]
 SetSignal<T> setSignal<T>(
-  Set<T> list, {
-  String? debugLabel,
-}) {
+  Set<T> list, [
+  String debugLabel = '',
+]) {
   return SetSignal<T>(
     list,
-    debugLabel: debugLabel,
+    debugLabel,
   );
 }

--- a/packages/signals/lib/src/value/stream_signal.dart
+++ b/packages/signals/lib/src/value/stream_signal.dart
@@ -45,7 +45,7 @@ class StreamSignal<T> extends ReadonlySignal<T?> {
     this._compute, {
     this.cancelOnError,
     this.fireImmediately = false,
-    this.debugLabel,
+    this.debugLabel = '',
     T? initial,
   }) : _state = signal<(_StreamState, T?, Object?)>((
           initial != null ? _StreamState.value : _StreamState.loading,
@@ -202,7 +202,7 @@ class StreamSignal<T> extends ReadonlySignal<T?> {
   T? get() => value;
 
   @override
-  final String? debugLabel;
+  final String debugLabel;
 
   @override
   int get globalId => _state.globalId;
@@ -238,7 +238,7 @@ StreamSignal<T> streamSignal<T>(
   Stream<T> Function() stream, {
   bool? cancelOnError,
   bool fireImmediately = false,
-  String? debugLabel,
+  String debugLabel = '',
 }) {
   return StreamSignal<T>(
     stream,


### PR DESCRIPTION
A first review that encourage to name signal.
Benefits are evident when combined with SignalObserver and DevTools.

Negative can be that I push for _optional parameters_ so they're shorts 
and very expressive but later down the road it may limit the use of 
_named parameters_

To the last point I wish to reiterate that soon we may have to rely 
on Options parameters then it will be a streamlined API.

It prepare further commits that favor 'optional' descriptive ops.

