### PR TITLE
Introduction to specific 'checks' test methods

### DIFF
--- a/packages/signals_core/lib/src/utils/test_checks.dart
+++ b/packages/signals_core/lib/src/utils/test_checks.dart
@@ -1,0 +1,14 @@
+import 'package:checks/context.dart';
+
+import '../../signals_core.dart';
+
+/// Extension on 'checks' test lib
+extension SignalChecks<T> on Subject<ReadonlySignal<T>?> {
+  /// Compare Signal<T>.peek() to ref T
+  Subject<T> peeked(T ref) {
+    return context.nest<T>(() => ['is not null'], (actual) {
+      if (actual == null) return Extracted.rejection();
+      return Extracted.value(actual.peek());
+    }, atSameLevel: true);
+  }
+}

--- a/packages/signals_core/pubspec.yaml
+++ b/packages/signals_core/pubspec.yaml
@@ -11,6 +11,7 @@ environment:
 dev_dependencies:
   lints: ^3.0.0
   test: ^1.24.0
+  checks: ^0.2.2
 
 topics:
   - signal


### PR DESCRIPTION
Checks from dart labs.
https://pub.dev/packages/checks

Introduce some ideas on how to make signals testable.

This is open for comment and right now is not exported since it's a specific libs.
User would have to import it directly.

``` dart
test() {
 final s = signal(100);
 check(s).peeked(100);
}
```

