### PR TITLE
[Memleak] Remove signal from cache when it's disposed.

### DIFF
--- a/packages/signals_core/lib/src/core/container.dart
+++ b/packages/signals_core/lib/src/core/container.dart
@@ -18,7 +18,13 @@ class SignalContainer<T, Arg, S extends ReadonlySignal<T>> {
   /// Create the signal with the given args
   S call(Arg arg) {
     if (cache) {
-      return _cache.putIfAbsent(arg, () => _create(arg));
+      return _cache.putIfAbsent(
+        arg,
+        () => _create(arg)
+          ..onDispose(() {
+            _cache.remove(arg);
+          }),
+      );
     } else {
       return _create(arg);
     }


### PR DESCRIPTION
Minor memory leak where signal is kept in cache even after it has been disposed.