### PR TITLE
fix: error in pattern matching example

### DIFF
--- a/website/src/content/docs/dart/async/state.md
+++ b/website/src/content/docs/dart/async/state.md
@@ -156,7 +156,7 @@ Instead of `map` and `maybeMap` it is also possible to use [dart switch expressi
 final signal = asyncSignal<int>(AsyncState.data(1));
 final value = switch (signal.value) {
     AsyncData<int> data => 'value: ${data.value}',
-    AsyncError<int> error => 'error: ${data.error}',
+    AsyncError<int> error => 'error: ${error.error}',
     AsyncLoading<int>() => 'loading',
 };
 ```


### PR DESCRIPTION
Appears to be an error in the code example regarding `AsyncState` pattern matching. The `error` property should be used in place of the `data` property.