### PR TITLE
Correct typo in documentation for read-only signals

### DIFF
--- a/packages/signals_core/lib/src/core/signal.dart
+++ b/packages/signals_core/lib/src/core/signal.dart
@@ -22,7 +22,7 @@ part of 'signals.dart';
 /// ```
 typedef SignalEquality<T> = bool Function(T previous, T value);
 
-/// Read only signals can just retrive a value but not update or cause mutations
+/// Read only signals can just retrieve a value but not update or cause mutations
 abstract class ReadonlySignal<T> {
   List<_Listenable> get _allTargets;
 


### PR DESCRIPTION
This PR corrects a typo in the documentation, changing "retrive" to "retrieve" for read-only signals.