### PR TITLE
[Minor] Remove unnecessary casts

### DIFF
--- a/packages/signals_core/lib/src/core/signal.dart
+++ b/packages/signals_core/lib/src/core/signal.dart
@@ -131,7 +131,7 @@ abstract class Signal<T> implements ReadonlySignal<T> {
   /// Set the current value
   void set(T value);
 
-  ReadonlySignal<T> readonly() => this as ReadonlySignal<T>;
+  ReadonlySignal<T> readonly() => this;
 }
 
 class _Signal<T> extends Signal<T> {
@@ -386,5 +386,5 @@ ReadonlySignal<T> readonlySignal<T>(
     value,
     debugLabel: debugLabel,
     equality: equality,
-  ).readonly();
+  );
 }


### PR DESCRIPTION
A `Signal` already implements `ReadonlySignal` so there's no need to cast it. This also means that the `readonly()` isn't needed because you can pass a `Signal` anywhere that requires a `ReadonlySignal`. I left it there so this wouldn't be a breaking change.