### PR TITLE
Specify non-nullability in `AsyncData` and `AsyncError`

### DIFF
--- a/packages/signals_core/lib/src/async/async_state.dart
+++ b/packages/signals_core/lib/src/async/async_state.dart
@@ -155,6 +155,9 @@ class AsyncData<T> extends AsyncState<T> {
 
   @override
   bool get hasError => false;
+
+  @override
+  T get value => super.value as T;
 }
 
 /// State for an [AsyncState] with an error
@@ -171,6 +174,9 @@ class AsyncError<T> extends AsyncState<T> {
 
   @override
   bool get hasError => true;
+
+  @override
+  Object get error => super.error!;
 }
 
 /// State for an [AsyncState] with a loading state

--- a/packages/signals_core/lib/src/async/future_signal.dart
+++ b/packages/signals_core/lib/src/async/future_signal.dart
@@ -49,12 +49,12 @@ class FutureSignal<T> extends AsyncSignal<T> {
   Future<void> reload() async {
     value = switch (value) {
       AsyncData<T> data => AsyncLoading<T>(
-          value: data.value as T,
+          value: data.value,
           hasValue: true,
           isLoading: false,
         ),
       AsyncError<T> err => AsyncLoading<T>(
-          error: (err.error!, err.stackTrace),
+          error: (err.error, err.stackTrace),
           hasError: true,
           isLoading: false,
         ),
@@ -68,11 +68,11 @@ class FutureSignal<T> extends AsyncSignal<T> {
   Future<void> refresh() async {
     value = switch (value) {
       AsyncData<T> data => AsyncData<T>(
-          data.value as T,
+          data.value,
           isLoading: true,
         ),
       AsyncError<T> err => AsyncError<T>(
-          err.error!,
+          err.error,
           err.stackTrace,
           isLoading: true,
         ),


### PR DESCRIPTION
This is a quick change that makes the types of `AsyncData.value` and `AsyncError.error` more specific, when you know the type of your AsyncValue (for example, when pattern-matching).

It's similar to [async](https://pub.dev/packages/async)'s [`Result`](https://pub.dev/documentation/async/latest/async/Result-class.html), where [`ValueResult.value`](https://pub.dev/documentation/async/latest/async/ValueResult/value.html) is guaranteed to be `T` rather than `T?`.