### PR TITLE
[Fix] allow reads when disposed.

### DIFF
--- a/packages/signals_core/lib/src/core/computed.dart
+++ b/packages/signals_core/lib/src/core/computed.dart
@@ -237,9 +237,8 @@ class _Computed<T> implements Computed<T>, _Listenable {
 
   @override
   T get value {
-    if (disposed) {
-      throw SignalsReadAfterDisposeError(this);
-    }
+    if (disposed) return this._value;
+
     if ((_flags & RUNNING) != 0) {
       _cycleDetected();
     }

--- a/packages/signals_core/lib/src/core/signal.dart
+++ b/packages/signals_core/lib/src/core/signal.dart
@@ -287,9 +287,8 @@ class _Signal<T> extends Signal<T> {
 
   @override
   T get value {
-    if (disposed) {
-      throw SignalsReadAfterDisposeError(this);
-    }
+    if (disposed) return this._value;
+
     final node = _addDependency(this);
     if (node != null) {
       node._version = this._version;

--- a/packages/signals_core/test/core/signals_test.dart
+++ b/packages/signals_core/test/core/signals_test.dart
@@ -5,6 +5,18 @@ import 'package:signals_core/signals_core.dart';
 import 'package:test/test.dart';
 
 void main() {
+  test('should work', () {
+    final a = signal(0);
+    final b = signal(0);
+
+    final c = computed(() => a.value + b.value);
+
+    a.dispose();
+
+    b.value = 1;
+
+    expect(c.value, 1);
+  });
   test('init', () {
     // Create signals
     final count = signal(0);
@@ -70,7 +82,7 @@ void main() {
         dispose();
         expect(s.disposed, true);
         expect(() => s.value = [3], throwsA(isA<SignalsError>()));
-        expect(() => s.value, throwsA(isA<SignalsError>()));
+        // expect(() => s.value, throwsA(isA<SignalsError>()));
       });
     });
 


### PR DESCRIPTION
re: https://github.com/rodydavis/signals.dart/issues/130#issuecomment-1927027159

This is a quick fix because I imagine the current behavior will break people's code.