### PR TITLE
ADD: IJ/AS IDE configs for all examples and tests

### DIFF
--- a/.run/Template Flutter.run.xml
+++ b/.run/Template Flutter.run.xml
@@ -1,0 +1,6 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="true" type="FlutterRunConfigurationType" factoryName="Flutter">
+    <option name="filePath" value="$PROJECT_DIR$/examples/auth_flow/lib/main.dart" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/Test signals_core.run.xml
+++ b/.run/Test signals_core.run.xml
@@ -1,0 +1,8 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Test signals_core" type="FlutterTestConfigType" factoryName="Flutter Test" singleton="false">
+    <option name="testDir" value="$PROJECT_DIR$/packages/signals_core/test" />
+    <option name="useRegexp" value="false" />
+    <option name="additionalArgs" value="" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/Test signals_flutter.run.xml
+++ b/.run/Test signals_flutter.run.xml
@@ -1,0 +1,8 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Test signals_flutter" type="FlutterTestConfigType" factoryName="Flutter Test" singleton="false">
+    <option name="testDir" value="$PROJECT_DIR$/packages/signals_flutter/test" />
+    <option name="useRegexp" value="false" />
+    <option name="additionalArgs" value="" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/async example .run.xml
+++ b/.run/async example .run.xml
@@ -1,0 +1,6 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="async example " type="DartCommandLineRunConfigurationType" factoryName="Dart Command Line Application">
+    <option name="filePath" value="$PROJECT_DIR$/examples/dart_examples/bin/async.dart" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/auth_flow example.run.xml
+++ b/.run/auth_flow example.run.xml
@@ -1,0 +1,6 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="auth_flow example" type="FlutterRunConfigurationType" factoryName="Flutter">
+    <option name="filePath" value="$PROJECT_DIR$/examples/auth_flow/lib/main.dart" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/clean_architecture example.run.xml
+++ b/.run/clean_architecture example.run.xml
@@ -1,0 +1,6 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="clean_architecture example" type="FlutterRunConfigurationType" factoryName="Flutter">
+    <option name="filePath" value="$PROJECT_DIR$/examples/clean_architecture/lib/main.dart" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/drift example.run.xml
+++ b/.run/drift example.run.xml
@@ -1,0 +1,6 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="drift example" type="FlutterRunConfigurationType" factoryName="Flutter">
+    <option name="filePath" value="$PROJECT_DIR$/examples/drift_example/lib/main.dart" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/eval_calculator example.run.xml
+++ b/.run/eval_calculator example.run.xml
@@ -1,0 +1,6 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="eval_calculator example" type="FlutterRunConfigurationType" factoryName="Flutter">
+    <option name="filePath" value="$PROJECT_DIR$/examples/eval_calculator/lib/main.dart" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/flutter_async example.run.xml
+++ b/.run/flutter_async example.run.xml
@@ -1,0 +1,6 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="flutter_async example" type="FlutterRunConfigurationType" factoryName="Flutter">
+    <option name="filePath" value="$PROJECT_DIR$/examples/flutter_async/lib/main.dart" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/flutter_colorband example.run.xml
+++ b/.run/flutter_colorband example.run.xml
@@ -1,0 +1,6 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="flutter_colorband example" type="FlutterRunConfigurationType" factoryName="Flutter">
+    <option name="filePath" value="$PROJECT_DIR$/examples/flutter_colorband/lib/main.dart" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/flutter_counter example.run.xml
+++ b/.run/flutter_counter example.run.xml
@@ -1,0 +1,6 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="flutter_counter example" type="FlutterRunConfigurationType" factoryName="Flutter">
+    <option name="filePath" value="$PROJECT_DIR$/examples/flutter_counter/lib/main.dart" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/get_it_signals example.run.xml
+++ b/.run/get_it_signals example.run.xml
@@ -1,0 +1,6 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="get_it_signals example" type="FlutterRunConfigurationType" factoryName="Flutter">
+    <option name="filePath" value="$PROJECT_DIR$/examples/get_it_signals/lib/main.dart" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/html_todo_app example.run.xml
+++ b/.run/html_todo_app example.run.xml
@@ -1,0 +1,6 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="html_todo_app example" type="FlutterRunConfigurationType" factoryName="Flutter">
+    <option name="filePath" value="$PROJECT_DIR$/examples/html_todo_app/web/main.dart" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/node_based_editor example.run.xml
+++ b/.run/node_based_editor example.run.xml
@@ -1,0 +1,6 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="node_based_editor example" type="FlutterRunConfigurationType" factoryName="Flutter">
+    <option name="filePath" value="$PROJECT_DIR$/examples/node_based_editor/lib/main.dart" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/operators example.run.xml
+++ b/.run/operators example.run.xml
@@ -1,0 +1,6 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="operators example" type="DartCommandLineRunConfigurationType" factoryName="Dart Command Line Application">
+    <option name="filePath" value="$PROJECT_DIR$/examples/dart_examples/bin/operators.dart" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/pipes example.run.xml
+++ b/.run/pipes example.run.xml
@@ -1,0 +1,6 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="pipes example" type="DartCommandLineRunConfigurationType" factoryName="Dart Command Line Application">
+    <option name="filePath" value="$PROJECT_DIR$/examples/dart_examples/bin/pipes.dart" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/shopping_cart example.run.xml
+++ b/.run/shopping_cart example.run.xml
@@ -1,0 +1,6 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="shopping_cart example" type="FlutterRunConfigurationType" factoryName="Flutter">
+    <option name="filePath" value="$PROJECT_DIR$/examples/shopping_cart/lib/main.dart" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/sqlite example.run.xml
+++ b/.run/sqlite example.run.xml
@@ -1,0 +1,6 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="sqlite example" type="DartCommandLineRunConfigurationType" factoryName="Dart Command Line Application">
+    <option name="filePath" value="$PROJECT_DIR$/examples/dart_examples/bin/sqlite.dart" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/timer example.run.xml
+++ b/.run/timer example.run.xml
@@ -1,0 +1,6 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="timer example" type="DartCommandLineRunConfigurationType" factoryName="Dart Command Line Application">
+    <option name="filePath" value="$PROJECT_DIR$/examples/dart_examples/bin/timer.dart" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/web html_todo_app example.run.xml
+++ b/.run/web html_todo_app example.run.xml
@@ -1,0 +1,8 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="web html_todo_app example" type="DartWebdevConfigurationType" factoryName="Dart Web">
+    <option name="htmlFilePath" value="$PROJECT_DIR$/examples/html_todo_app/web/index.html" />
+    <method v="2">
+      <option name="LaunchBrowser.Before.Run" browser="98ca6316-2f89-46d9-a9e5-fa9e2b0625b3" />
+    </method>
+  </configuration>
+</component>

--- a/.run/web rxdart example.run.xml
+++ b/.run/web rxdart example.run.xml
@@ -1,0 +1,8 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="web rxdart example" type="DartWebdevConfigurationType" factoryName="Dart Web">
+    <option name="htmlFilePath" value="$PROJECT_DIR$/examples/rxdart/web/index.html" />
+    <method v="2">
+      <option name="LaunchBrowser.Before.Run" browser="98ca6316-2f89-46d9-a9e5-fa9e2b0625b3" />
+    </method>
+  </configuration>
+</component>


### PR DESCRIPTION
This PR adds IDE configs for IntelliJ and Android Studio users so they get quick and easy menus to:

* Build and run the Flutter examples
* Build and run the Dart CLI examples
* Build and run the Web html examples
* Run the tests

I don't know if this is of interest, but as an IJ user I use them all time when I try out the examples and study them.

The PR adds a menu with following preconfigured options for IJ/AS:

![Screenshot 2024-02-08 at 20 44 48](https://github.com/rodydavis/signals.dart/assets/39990307/ab97f052-1f31-436c-bec6-79e7b6d2995b)

So you can try the Vanilla CLI/Console demos:

![Screenshot 2024-02-08 at 20 37 46](https://github.com/rodydavis/signals.dart/assets/39990307/7df755d1-de39-49fe-a63d-28df0c096947)

The WEB build demos:

![Screenshot 2024-02-08 at 20 35 18](https://github.com/rodydavis/signals.dart/assets/39990307/48414971-dde4-4438-9b13-76736ff66927)

And of course all the Flutter demos:

![Screenshot 2024-02-08 at 20 37 00](https://github.com/rodydavis/signals.dart/assets/39990307/05a9d538-cba6-470d-9d58-655473cb64d9)

