### PR TITLE
Remove unused onDispose method from Effect

### DIFF
--- a/packages/signals_core/lib/src/core/effect.dart
+++ b/packages/signals_core/lib/src/core/effect.dart
@@ -143,18 +143,7 @@ class _Effect implements _Listenable {
     }
   }
 
-  final _disposeCallbacks = <void Function()>{};
-
-  @override
-  void onDispose(void Function() cleanup) {
-    _disposeCallbacks.add(cleanup);
-  }
-
   void _dispose() {
-    for (final cleanup in _disposeCallbacks) {
-      cleanup();
-    }
-    _disposeCallbacks.clear();
     _flags |= DISPOSED;
     if (!((_flags & RUNNING) != 0)) {
       _disposeEffect(this);

--- a/packages/signals_core/lib/src/core/signals.dart
+++ b/packages/signals_core/lib/src/core/signals.dart
@@ -194,8 +194,6 @@ abstract class _Listenable {
 
   void _notify();
 
-  void onDispose(void Function() cleanup);
-
   void dispose();
 }
 


### PR DESCRIPTION
The `onDispose()` is never used for effects so it just clutters on the code. The `_Effect` class is never exposed to the user so they can't call `onDispose` on it.

This PR:
Removed it from the _Listenable and _Effect classes. This doesn't affect `computed` because the method already exists on the `ReadonlySignal` abstract class.