### PR TITLE
Add ability to unregister a dispose callback

### DIFF
--- a/packages/signals_core/lib/src/core/computed.dart
+++ b/packages/signals_core/lib/src/core/computed.dart
@@ -296,8 +296,12 @@ class _Computed<T> implements Computed<T>, _Listenable {
   final _disposeCallbacks = <void Function()>{};
 
   @override
-  void onDispose(void Function() cleanup) {
+  EffectCleanup onDispose(void Function() cleanup) {
     _disposeCallbacks.add(cleanup);
+
+    return () {
+      _disposeCallbacks.remove(cleanup);
+    };
   }
 
   @override

--- a/packages/signals_core/lib/src/core/signal.dart
+++ b/packages/signals_core/lib/src/core/signal.dart
@@ -107,7 +107,7 @@ abstract class ReadonlySignal<T> {
 
   void dispose();
 
-  void onDispose(void Function() cleanup);
+  EffectCleanup onDispose(void Function() cleanup);
 }
 
 /// The `signal` function creates a new signal. A signal is a container for
@@ -359,8 +359,12 @@ class _Signal<T> extends Signal<T> {
   final _disposeCallbacks = <void Function()>{};
 
   @override
-  void onDispose(void Function() cleanup) {
+  EffectCleanup onDispose(void Function() cleanup) {
     _disposeCallbacks.add(cleanup);
+
+    return () {
+      _disposeCallbacks.remove(cleanup);
+    };
   }
 
   @override

--- a/packages/signals_core/test/core/signals_test.dart
+++ b/packages/signals_core/test/core/signals_test.dart
@@ -72,6 +72,15 @@ void main() {
         expect(calls, 1);
       });
 
+      test('should remove dispose callback', () {
+        final a = signal(10);
+        var calls = 0;
+        final cancel = a.onDispose(() => calls++);
+        cancel();
+        a.dispose();
+        expect(calls, 0);
+      });
+
       test('read/write after dispose should throw', () {
         int calls = 0;
         final v = [1, 2];


### PR DESCRIPTION
It's generally a good practice to provide a way to unregister listeners.  This is useful when you want to  allow resources captured by the callback to be freed by the GC.

```dart
final completer = Completer<T>();
final unsub = subscribe(completer.complete);

// if the signal is disposed before a new value is emitted,
// complete the future with the current value.
// Without this, the future would hang indefinitely
final rmCallback = onDispose(() {
   if (completer.isCompleted) return;
   completer.complete(peek());
});

final result = await completer.future;

unsub();

// the Completer was captured by the dispose closure
// this allows the completer to be garbage collected
rmCallback(); 

return result;
```