### PR TITLE
Fix the repository link in signals_lint

### DIFF
--- a/packages/signals_lint/pubspec.yaml
+++ b/packages/signals_lint/pubspec.yaml
@@ -1,7 +1,7 @@
 name: signals_lint
 description: linter and developer tool for signals
 version: 4.2.0
-repository: https://github.com/rodyavis/signals
+repository: https://github.com/rodydavis/signals.dart
 documentation: https://rodydavis.github.io/signals.dart/
 topics:
   - state-management


### PR DESCRIPTION
Took me some time to figure out why I couldn't access the repository from the pub package for the lint :P