### PR TITLE
Wrapped the update processing of AsyncSignal.value in a batch

### DIFF
--- a/packages/signals_core/lib/src/async/signal.dart
+++ b/packages/signals_core/lib/src/async/signal.dart
@@ -190,29 +190,37 @@ class AsyncSignal<T> extends ValueSignal<AsyncState<T>> {
 
   /// Set the error with optional stackTrace to [AsyncError]
   void setError(Object error, [StackTrace? stackTrace]) {
-    value = AsyncState.error(error, stackTrace);
-    if (_completer.isCompleted) _completer = Completer<bool>();
-    _completer.complete(true);
+    batch(() {
+      value = AsyncState.error(error, stackTrace);
+      if (_completer.isCompleted) _completer = Completer<bool>();
+      _completer.complete(true);
+    });
   }
 
   /// Set the value to [AsyncData]
   void setValue(T value) {
-    this.value = AsyncState.data(value);
-    if (_completer.isCompleted) _completer = Completer<bool>();
-    _completer.complete(true);
+    batch(() {
+      this.value = AsyncState.data(value);
+      if (_completer.isCompleted) _completer = Completer<bool>();
+      _completer.complete(true);
+    });
   }
 
   /// Set the loading state to [AsyncLoading]
   void setLoading([AsyncState<T>? state]) {
-    value = state ?? AsyncState.loading();
-    _completer = Completer<bool>();
+    batch(() {
+      value = state ?? AsyncState.loading();
+      _completer = Completer<bool>();
+    });
   }
 
   /// Reset the signal to the initial value
   void reset([AsyncState<T>? value]) {
-    this.value = value ?? _initialValue;
-    _initialized = false;
-    if (_completer.isCompleted) _completer = Completer<bool>();
+    batch(() {
+      this.value = value ?? _initialValue;
+      _initialized = false;
+      if (_completer.isCompleted) _completer = Completer<bool>();
+    });
   }
 
   /// Initialize the signal


### PR DESCRIPTION
When AsyncSignal.value is updated, the value propagates to the monitoring side while the state of _completer is not synchronized, so it has been fixed to ensure that the state of _completer is synchronized.
By synchronizing, when AsyncData flows to subscribe, isCompleted simultaneously becomes true.