### PR TITLE
Minor refactor

### DIFF
--- a/packages/signals_flutter/lib/src/signals/core/computed.dart
+++ b/packages/signals_flutter/lib/src/signals/core/computed.dart
@@ -68,7 +68,7 @@ Computed<T> bindComputed<T, S extends StatefulWidget>(
     () {
       target.value;
       final context = widget.context;
-      if (context is Element && context.mounted && !context.dirty) {
+      if (context is Element && context.mounted) {
         context.markNeedsBuild();
       }
     },

--- a/packages/signals_flutter/lib/src/signals/core/effect.dart
+++ b/packages/signals_flutter/lib/src/signals/core/effect.dart
@@ -44,8 +44,8 @@ void Function() createEffect<S extends StatefulWidget>(
     debugLabel: debugLabel,
     onDispose: onDispose,
   );
-  if (widget is SignalsAutoDisposeMixin) {
-    (widget as SignalsAutoDisposeMixin).addEffectDisposeCallback(dispose);
+  if (widget case SignalsAutoDisposeMixin w) {
+    w.addEffectDisposeCallback(dispose);
   }
   return dispose;
 }

--- a/packages/signals_flutter/lib/src/signals/core/signal.dart
+++ b/packages/signals_flutter/lib/src/signals/core/signal.dart
@@ -65,7 +65,7 @@ Signal<T> bindSignal<T, S extends StatefulWidget>(
     () {
       target.value;
       final context = widget.context;
-      if (context is Element && context.mounted && !context.dirty) {
+      if (context is Element && context.mounted) {
         context.markNeedsBuild();
       }
     },


### PR DESCRIPTION
This is just some small improvements to the code.

You don't have to check `context.dirty` because `markNeedsBuild()` already does this:

https://github.com/flutter/flutter/blob/34b454f42dd6f8721dfe43fc7de5d215705b5e52/packages/flutter/lib/src/widgets/framework.dart#L5060

```dart
void markNeedsBuild() {
 //...//
 if (dirty) {
      return;
    }
 _dirty = true;
 owner!.scheduleBuildFor(this);
}
```