### PR TITLE
feat: Changed Async{Loading,Data,Error} to be const

### DIFF
--- a/packages/signals_core/lib/src/async/state.dart
+++ b/packages/signals_core/lib/src/async/state.dart
@@ -332,7 +332,7 @@ sealed class AsyncState<T> {
 /// State for an [AsyncState] with a value
 class AsyncData<T> extends AsyncState<T> {
   /// State for an [AsyncState] with a value
-  AsyncData(
+  const AsyncData(
     T data, {
     super.isLoading = false,
     super.error,
@@ -351,7 +351,7 @@ class AsyncData<T> extends AsyncState<T> {
 /// State for an [AsyncState] with an error
 class AsyncError<T> extends AsyncState<T> {
   /// State for an [AsyncState] with an error
-  AsyncError(
+  const AsyncError(
     Object error,
     StackTrace? stackTrace, {
     super.isLoading = false,
@@ -371,7 +371,7 @@ class AsyncError<T> extends AsyncState<T> {
 /// State for an [AsyncState] with a loading state
 class AsyncLoading<T> extends AsyncState<T> {
   /// State for an [AsyncState] with a loading state
-  AsyncLoading({
+  const AsyncLoading({
     super.value,
     super.error,
     super.isLoading = true,


### PR DESCRIPTION
As these are created with immutability in mind; I don't see any side effects in having these be `const`.

Happy to review if there's a specific reason I'm missing here though.