### PR TITLE
Feat: added `refreshAndAwait()` to set refresh and await until the loading completes

### DIFF
--- a/packages/signals_core/lib/src/async/future.dart
+++ b/packages/signals_core/lib/src/async/future.dart
@@ -183,6 +183,26 @@ class FutureSignal<T> extends StreamSignal<T> {
           () => callback().asStream(),
           cancelOnError: true,
         );
+
+  /// `super.refresh()` but returns a future that completes when the future is done loading.
+  /// 
+  /// Good use in a [RefreshIndicator].
+  /// So that the refresh indicator will show until the future is done loading.
+  /// ```dart
+  /// final mySignal = futureSignal(() async => Future.delayed(Duration(seconds: 5), () => 1);
+  /// 
+  /// RefreshIndicator(
+  ///  onRefresh: mySignal.refreshAndAwait,
+  ///  child: ...
+  /// )
+  /// ```
+  /// 
+  Future<void> refreshAndAwait() async {
+    super.refresh();
+    return await Future.doWhile(
+      () => Future.delayed(Duration.zero, () => super.value.isLoading),
+    );
+  }
 }
 
 /// {@template future}

--- a/website/src/content/docs/async/future.md
+++ b/website/src/content/docs/async/future.md
@@ -59,6 +59,15 @@ s.reload();
 print(s.value is AsyncLoading); // true
 ```
 
+## .refreshAndAwait()
+
+Refresh the future value and await the future to complete, unlike `refresh` which only changes the state and does not wait for the future to complete.
+
+```dart
+final s = futureSignal(() => Future.delayed(const Duration(seconds:2), () => 1));
+await s.refreshAndAwait(); // waits for 2 seconds
+```
+
 ## Dependencies
 
 By default the callback will be called once and the future will be cached unless a signal is read in the callback.
@@ -72,7 +81,7 @@ count.value = 1;
 await s.future; // 1
 ```
 
-If there are signals that need to be tracked across an async gap then use the `dependencies` when creating the `futureSignal` to [`reset`](#.reset()) every time any signal in the dependency array changes.
+If there are signals that need to be tracked across an async gap then use the `dependencies` when creating the `futureSignal` to [`reset`](<#.reset()>) every time any signal in the dependency array changes.
 
 ```dart
 final count = signal(0);


### PR DESCRIPTION
Added `.refreshAndAwait()` to `FutureSignal` in order to do `.refresh()` but instead of it just changing the state it awaits the future to recompute and finishes the refreshing

good for drag down to refresh indicators and other loading indicators that rely on completing futures 
since isRefreshing/isReloading is different than isLoading
