### PR TITLE
Lazy signal should not trigger SignalObserver.created

### DIFF
--- a/packages/signals_core/lib/src/core/signal.dart
+++ b/packages/signals_core/lib/src/core/signal.dart
@@ -235,7 +235,7 @@ class Signal<T> extends ReadonlySignal<T> {
   })  : _lazy = true,
         super._(globalId: ++_lastGlobalId) {
     assert(() {
-      SignalsObserver.instance?.onSignalCreated(this);
+      if (!_lazy) SignalsObserver.instance?.onSignalCreated(this);
       return true;
     }());
   }


### PR DESCRIPTION
If an Observer implementation access a lazy signal it will throw.

Setup a test with SignalObserver, any lazy signal will fail.