### PR TITLE
Attach the debugLabel to the AWatch

### DIFF
--- a/packages/signals_flutter/lib/src/watch/widget.dart
+++ b/packages/signals_flutter/lib/src/watch/widget.dart
@@ -178,7 +178,7 @@ class Watch<T extends Widget> extends StatefulWidget {
 }
 
 class _WatchState<T extends Widget> extends State<Watch<T>> with SignalsMixin {
-  late final result = this.createComputed(() => widget.builder(context));
+  late final result = this.createComputed(() => widget.builder(context), debugLabel: widget.debugLabel);
   bool _init = true;
 
   @override


### PR DESCRIPTION
pass the debugLabel to the computed signal so that dev tools shows its name.