### PR TITLE
chore(docs): replace SignalsAutoDisposeMixin with SignalsMixin

### DIFF
--- a/packages/signals/README.md
+++ b/packages/signals/README.md
@@ -237,7 +237,7 @@ class Counter extends StatefulWidget {
   _CounterState createState() => _CounterState();
 }
 
-class _CounterState extends State<Counter> with SignalsAutoDisposeMixin {
+class _CounterState extends State<Counter> with SignalsMixin {
   late final counter = createSignal(context, 0);
   late final isEven = createComputed(context, () => counter.value.isEven);
   late final isOdd = createComputed(context, () => counter.value.isOdd);
@@ -259,7 +259,7 @@ class _CounterState extends State<Counter> with SignalsAutoDisposeMixin {
 }
 ```
 
-The `SignalsAutoDisposeMixin` is a mixin that automatically disposes all signals created in the state when the widget is removed from the widget tree.
+The `SignalsMixin` is a mixin that automatically disposes all signals created in the state when the widget is removed from the widget tree.
 
 #### Fine Grained Rebuilding
 

--- a/packages/signals_core/lib/src/core/computed.dart
+++ b/packages/signals_core/lib/src/core/computed.dart
@@ -99,7 +99,7 @@ part of 'signals.dart';
 ///   _CounterWidgetState createState() => _CounterWidgetState();
 /// }
 ///
-/// class _CounterWidgetState extends State<CounterWidget> with SignalsAutoDisposeMixin {
+/// class _CounterWidgetState extends State<CounterWidget> with SignalsMixin {
 ///   late final counter = createSignal(context, 0);
 ///   late final isEven = createComputed(context, () => counter.value.isEven);
 ///   late final isOdd = createComputed(context, () => counter.value.isOdd);
@@ -126,7 +126,7 @@ part of 'signals.dart';
 ///
 /// No `Watch` widget or extension is needed, the signal will automatically dispose itself when the widget is removed from the widget tree.
 ///
-/// The `SignalsAutoDisposeMixin` is a mixin that automatically disposes all signals created in the state when the widget is removed from the widget tree.
+/// The `SignalsMixin` is a mixin that automatically disposes all signals created in the state when the widget is removed from the widget tree.
 ///
 /// ## Testing
 ///
@@ -269,7 +269,7 @@ class Computed<T> extends ReadonlySignal<T> implements SignalListenable {
   ///   _CounterWidgetState createState() => _CounterWidgetState();
   /// }
   ///
-  /// class _CounterWidgetState extends State<CounterWidget> with SignalsAutoDisposeMixin {
+  /// class _CounterWidgetState extends State<CounterWidget> with SignalsMixin {
   ///   late final counter = createSignal(context, 0);
   ///   late final isEven = createComputed(context, () => counter.value.isEven);
   ///   late final isOdd = createComputed(context, () => counter.value.isOdd);
@@ -296,7 +296,7 @@ class Computed<T> extends ReadonlySignal<T> implements SignalListenable {
   ///
   /// No `Watch` widget or extension is needed, the signal will automatically dispose itself when the widget is removed from the widget tree.
   ///
-  /// The `SignalsAutoDisposeMixin` is a mixin that automatically disposes all signals created in the state when the widget is removed from the widget tree.
+  /// The `SignalsMixin` is a mixin that automatically disposes all signals created in the state when the widget is removed from the widget tree.
   ///
   /// ## Testing
   ///
@@ -655,7 +655,7 @@ typedef ComputedCallback<T> = T Function();
 ///   _CounterWidgetState createState() => _CounterWidgetState();
 /// }
 ///
-/// class _CounterWidgetState extends State<CounterWidget> with SignalsAutoDisposeMixin {
+/// class _CounterWidgetState extends State<CounterWidget> with SignalsMixin {
 ///   late final counter = createSignal(context, 0);
 ///   late final isEven = createComputed(context, () => counter.value.isEven);
 ///   late final isOdd = createComputed(context, () => counter.value.isOdd);
@@ -682,7 +682,7 @@ typedef ComputedCallback<T> = T Function();
 ///
 /// No `Watch` widget or extension is needed, the signal will automatically dispose itself when the widget is removed from the widget tree.
 ///
-/// The `SignalsAutoDisposeMixin` is a mixin that automatically disposes all signals created in the state when the widget is removed from the widget tree.
+/// The `SignalsMixin` is a mixin that automatically disposes all signals created in the state when the widget is removed from the widget tree.
 ///
 /// ## Testing
 ///

--- a/packages/signals_core/lib/src/core/signal.dart
+++ b/packages/signals_core/lib/src/core/signal.dart
@@ -138,7 +138,7 @@ part of 'signals.dart';
 ///   _CounterWidgetState createState() => _CounterWidgetState();
 /// }
 ///
-/// class _CounterWidgetState extends State<CounterWidget> with SignalsAutoDisposeMixin {
+/// class _CounterWidgetState extends State<CounterWidget> with SignalsMixin {
 ///   late final counter = createSignal(context, 0);
 ///
 ///   @override
@@ -163,7 +163,7 @@ part of 'signals.dart';
 ///
 /// No `Watch` widget or extension is needed, the signal will automatically dispose itself when the widget is removed from the widget tree.
 ///
-/// The `SignalsAutoDisposeMixin` is a mixin that automatically disposes all signals created in the state when the widget is removed from the widget tree.
+/// The `SignalsMixin` is a mixin that automatically disposes all signals created in the state when the widget is removed from the widget tree.
 ///
 /// ## Testing
 ///
@@ -342,7 +342,7 @@ class Signal<T> extends ReadonlySignal<T> {
   ///   _CounterWidgetState createState() => _CounterWidgetState();
   /// }
   ///
-  /// class _CounterWidgetState extends State<CounterWidget> with SignalsAutoDisposeMixin {
+  /// class _CounterWidgetState extends State<CounterWidget> with SignalsMixin {
   ///   late final counter = createSignal(context, 0);
   ///
   ///   @override
@@ -367,7 +367,7 @@ class Signal<T> extends ReadonlySignal<T> {
   ///
   /// No `Watch` widget or extension is needed, the signal will automatically dispose itself when the widget is removed from the widget tree.
   ///
-  /// The `SignalsAutoDisposeMixin` is a mixin that automatically disposes all signals created in the state when the widget is removed from the widget tree.
+  /// The `SignalsMixin` is a mixin that automatically disposes all signals created in the state when the widget is removed from the widget tree.
   ///
   /// ## Testing
   ///
@@ -742,7 +742,7 @@ class Signal<T> extends ReadonlySignal<T> {
 ///   _CounterWidgetState createState() => _CounterWidgetState();
 /// }
 ///
-/// class _CounterWidgetState extends State<CounterWidget> with SignalsAutoDisposeMixin {
+/// class _CounterWidgetState extends State<CounterWidget> with SignalsMixin {
 ///   late final counter = createSignal(context, 0);
 ///
 ///   @override
@@ -767,7 +767,7 @@ class Signal<T> extends ReadonlySignal<T> {
 ///
 /// No `Watch` widget or extension is needed, the signal will automatically dispose itself when the widget is removed from the widget tree.
 ///
-/// The `SignalsAutoDisposeMixin` is a mixin that automatically disposes all signals created in the state when the widget is removed from the widget tree.
+/// The `SignalsMixin` is a mixin that automatically disposes all signals created in the state when the widget is removed from the widget tree.
 ///
 /// ## Testing
 ///

--- a/website/src/content/docs/core/computed.md
+++ b/website/src/content/docs/core/computed.md
@@ -101,7 +101,7 @@ class CounterWidget extends StatefulWidget {
   _CounterWidgetState createState() => _CounterWidgetState();
 }
 
-class _CounterWidgetState extends State<CounterWidget> with SignalsAutoDisposeMixin {
+class _CounterWidgetState extends State<CounterWidget> with SignalsMixin {
   late final counter = createSignal(context, 0);
   late final isEven = createComputed(context, () => counter.value.isEven);
   late final isOdd = createComputed(context, () => counter.value.isOdd);
@@ -128,7 +128,7 @@ class _CounterWidgetState extends State<CounterWidget> with SignalsAutoDisposeMi
 
 No `Watch` widget or extension is needed, the signal will automatically dispose itself when the widget is removed from the widget tree.
 
-The `SignalsAutoDisposeMixin` is a mixin that automatically disposes all signals created in the state when the widget is removed from the widget tree.
+The `SignalsMixin` is a mixin that automatically disposes all signals created in the state when the widget is removed from the widget tree.
 
 ## Testing
 

--- a/website/src/content/docs/core/signal.md
+++ b/website/src/content/docs/core/signal.md
@@ -140,7 +140,7 @@ class CounterWidget extends StatefulWidget {
   _CounterWidgetState createState() => _CounterWidgetState();
 }
 
-class _CounterWidgetState extends State<CounterWidget> with SignalsAutoDisposeMixin {
+class _CounterWidgetState extends State<CounterWidget> with SignalsMixin {
   late final counter = createSignal(context, 0);
 
   @override
@@ -165,7 +165,7 @@ class _CounterWidgetState extends State<CounterWidget> with SignalsAutoDisposeMi
 
 No `Watch` widget or extension is needed, the signal will automatically dispose itself when the widget is removed from the widget tree.
 
-The `SignalsAutoDisposeMixin` is a mixin that automatically disposes all signals created in the state when the widget is removed from the widget tree.
+The `SignalsMixin` is a mixin that automatically disposes all signals created in the state when the widget is removed from the widget tree.
 
 ## Testing
 


### PR DESCRIPTION
Because `SignalsAutoDisposeMixin` is deprecated but still referenced in the documentation. I updated the docs and replaced `SignalsAutoDisposeMixin` with `SignalsMixin`