### PR TITLE
Updates related to 6 0 0

### DIFF
--- a/examples/animations_example/pubspec.yaml
+++ b/examples/animations_example/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
     sdk: flutter
 
   cupertino_icons: ^1.0.6
-  signals: ^5.5.0
+  signals: ^6.0.0
 
 dev_dependencies:
   flutter_test:

--- a/examples/auth_flow/pubspec.yaml
+++ b/examples/auth_flow/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
     sdk: flutter
 
   cupertino_icons: ^1.0.8
-  signals: ^5.5.0
+  signals: ^6.0.0
   go_router: ^13.2.4
 
 dev_dependencies:

--- a/examples/clean_architecture/pubspec.yaml
+++ b/examples/clean_architecture/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
 
   cupertino_icons: ^1.0.8
   sqlite_async: ^0.6.1
-  signals: ^5.5.0
+  signals: ^6.0.0
   path_provider: ^2.1.3
 
 dev_dependencies:

--- a/examples/crud_dio/pubspec.yaml
+++ b/examples/crud_dio/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
     sdk: flutter
 
   cupertino_icons: ^1.0.8
-  signals: ^5.5.0
+  signals: ^6.0.0
   dio: ^5.4.3+1
   retrofit: ^4.1.0
   json_annotation: ^4.8.1

--- a/examples/dart_examples/pubspec.yaml
+++ b/examples/dart_examples/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 
 dependencies:
   collection: ^1.18.0
-  signals: ^5.5.0
+  signals: ^6.0.0
   sqlite_async: ^0.6.1
   test: ^1.25.2
 

--- a/examples/dart_mappable_example/pubspec.yaml
+++ b/examples/dart_mappable_example/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   dart_mappable: ^4.2.2
   flutter:
     sdk: flutter
-  signals: ^5.5.0
+  signals: ^6.0.0
 
 dev_dependencies:
   flutter_test:

--- a/examples/drift_example/pubspec.yaml
+++ b/examples/drift_example/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   path_provider: ^2.1.3
   path: ^1.9.0
   go_router: ^13.2.4
-  signals: ^5.5.0
+  signals: ^6.0.0
   flutter_colorpicker: ^1.0.3
   file_picker: ^8.0.0+1
   sqlite3: ^2.4.2

--- a/examples/eval_calculator/pubspec.yaml
+++ b/examples/eval_calculator/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  signals: ^5.5.0
+  signals: ^6.0.0
   analyzer: '>=6.4.1'
   cupertino_icons: ^1.0.8
   material_table_view: ^4.0.2

--- a/examples/flutter_async/pubspec.yaml
+++ b/examples/flutter_async/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
   cupertino_icons: ^1.0.8
-  signals: ^5.5.0
+  signals: ^6.0.0
 
 dev_dependencies:
   flutter_test:

--- a/examples/flutter_colorband/pubspec.yaml
+++ b/examples/flutter_colorband/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  signals: ^5.5.0
+  signals: ^6.0.0
   rxdart: ^0.27.7
   flutter_xlider: ^3.5.0
   layout: ^1.0.5

--- a/examples/flutter_counter/pubspec.yaml
+++ b/examples/flutter_counter/pubspec.yaml
@@ -9,7 +9,7 @@ dependencies:
   flutter:
     sdk: flutter
   cupertino_icons: ^1.0.8
-  signals: ^5.5.0
+  signals: ^6.0.0
 
 dev_dependencies:
   flutter_test:

--- a/examples/get_it_signals/pubspec.yaml
+++ b/examples/get_it_signals/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
     sdk: flutter
   get_it: ^7.7.0
   go_router: ^13.2.4
-  signals: ^5.5.0
+  signals: ^6.0.0
 
 dev_dependencies:
   flutter_test:

--- a/examples/html_canvas/pubspec.yaml
+++ b/examples/html_canvas/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 
 dependencies:
   web: ^0.5.1
-  signals: ^5.5.0
+  signals: ^6.0.0
 
 dev_dependencies:
   build_runner: ^2.4.9

--- a/examples/html_todo_app/pubspec.yaml
+++ b/examples/html_todo_app/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 
 dependencies:
   web: ^0.5.1
-  signals: ^5.5.0
+  signals: ^6.0.0
 
 dev_dependencies:
   build_runner: ^2.4.9

--- a/examples/infinite_scroll/pubspec.yaml
+++ b/examples/infinite_scroll/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  signals: ^5.5.0
+  signals: ^6.0.0
 
 dev_dependencies:
   flutter_test:

--- a/examples/node_based_editor/pubspec.yaml
+++ b/examples/node_based_editor/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  signals: ^5.5.0
+  signals: ^6.0.0
 
 dev_dependencies:
   flutter_test:

--- a/examples/persist_shared_preferences/pubspec.yaml
+++ b/examples/persist_shared_preferences/pubspec.yaml
@@ -9,7 +9,7 @@ dependencies:
   flutter:
     sdk: flutter
   cupertino_icons: ^1.0.8
-  signals: ^5.5.0
+  signals: ^6.0.0
   shared_preferences: ^2.2.3
 
 dev_dependencies:

--- a/examples/rxdart/pubspec.yaml
+++ b/examples/rxdart/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   collection: ^1.18.0
   rxdart: ^0.27.7
-  signals: ^5.5.0
+  signals: ^6.0.0
 
 dev_dependencies:
   build_runner: ^2.4.9

--- a/examples/shopping_cart/pubspec.yaml
+++ b/examples/shopping_cart/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   flutter_localizations:
     sdk: flutter
   lite_ref: ^0.7.0
-  signals: ^5.5.0
+  signals: ^6.0.0
 
 dev_dependencies:
   flutter_lints: ^3.0.2

--- a/packages/signals/README.md
+++ b/packages/signals/README.md
@@ -238,9 +238,9 @@ class Counter extends StatefulWidget {
 }
 
 class _CounterState extends State<Counter> with SignalsMixin {
-  late final counter = createSignal(context, 0);
-  late final isEven = createComputed(context, () => counter.value.isEven);
-  late final isOdd = createComputed(context, () => counter.value.isOdd);
+  late final counter = createSignal(0);
+  late final isEven = createComputed(() => counter.value.isEven);
+  late final isOdd = createComputed(() => counter.value.isOdd);
 
   @override
   Widget build(BuildContext context) {

--- a/packages/signals_core/lib/src/core/computed.dart
+++ b/packages/signals_core/lib/src/core/computed.dart
@@ -100,9 +100,9 @@ part of 'signals.dart';
 /// }
 ///
 /// class _CounterWidgetState extends State<CounterWidget> with SignalsMixin {
-///   late final counter = createSignal(context, 0);
-///   late final isEven = createComputed(context, () => counter.value.isEven);
-///   late final isOdd = createComputed(context, () => counter.value.isOdd);
+///   late final counter = createSignal(0);
+///   late final isEven = createComputed(() => counter.value.isEven);
+///   late final isOdd = createComputed(() => counter.value.isOdd);
 ///
 ///   @override
 ///   Widget build(BuildContext context) {
@@ -272,9 +272,9 @@ class Computed<T> extends signals.Computed<T>
   /// }
   ///
   /// class _CounterWidgetState extends State<CounterWidget> with SignalsMixin {
-  ///   late final counter = createSignal(context, 0);
-  ///   late final isEven = createComputed(context, () => counter.value.isEven);
-  ///   late final isOdd = createComputed(context, () => counter.value.isOdd);
+  ///   late final counter = createSignal(0);
+  ///   late final isEven = createComputed(() => counter.value.isEven);
+  ///   late final isOdd = createComputed(() => counter.value.isOdd);
   ///
   ///   @override
   ///   Widget build(BuildContext context) {
@@ -530,9 +530,9 @@ typedef ComputedCallback<T> = T Function();
 /// }
 ///
 /// class _CounterWidgetState extends State<CounterWidget> with SignalsMixin {
-///   late final counter = createSignal(context, 0);
-///   late final isEven = createComputed(context, () => counter.value.isEven);
-///   late final isOdd = createComputed(context, () => counter.value.isOdd);
+///   late final counter = createSignal(0);
+///   late final isEven = createComputed(() => counter.value.isEven);
+///   late final isOdd = createComputed(() => counter.value.isOdd);
 ///
 ///   @override
 ///   Widget build(BuildContext context) {

--- a/packages/signals_core/lib/src/core/signal.dart
+++ b/packages/signals_core/lib/src/core/signal.dart
@@ -289,7 +289,7 @@ class Signal<T> extends signals.Signal<T>
 /// }
 ///
 /// class _CounterWidgetState extends State<CounterWidget> with SignalsAutoDisposeMixin {
-///   late final counter = createSignal(context, 0);
+///   late final counter = createSignal(0);
 ///
 ///   @override
 ///   Widget build(BuildContext context) {

--- a/packages/signals_lint/example/lib/main.dart
+++ b/packages/signals_lint/example/lib/main.dart
@@ -22,8 +22,8 @@ class MyHomePage extends StatefulWidget {
   State<MyHomePage> createState() => _MyHomePageState();
 }
 
-class _MyHomePageState extends State<MyHomePage> {
-  late final counter = createSignal(context, 1);
+class _MyHomePageState extends State<MyHomePage> with SignalsMixin {
+  late final counter = createSignal(1);
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
The example pubspecs needed to updated to 6.0.0, there was also one small related error in lints (since the `createSignal`) change, and some small doc changes.

Merge https://github.com/rodydavis/signals.dart/pull/353 first