### PR TITLE
Refactor: Rename persisted signal classes to correct typo

### DIFF
--- a/packages/signals_core/lib/src/persisted/bool.dart
+++ b/packages/signals_core/lib/src/persisted/bool.dart
@@ -21,9 +21,9 @@ class PersistedBoolSignal extends PersistedSignal<bool> {
 }
 
 /// A `PersistedSignal` that stores a nullable string value.
-class PersistedPersistedBoolSignal extends PersistedSignal<bool?> {
-  /// Creates a new `PersistedBoolSignal`.
-  PersistedPersistedBoolSignal(
+class PersistedNullableBoolSignal extends PersistedSignal<bool?> {
+  /// Creates a new `NullableBoolSignal`.
+  PersistedNullableBoolSignal(
     super.val,
     String key, {
     SignalsKeyValueStore? store,

--- a/packages/signals_core/lib/src/persisted/enum.dart
+++ b/packages/signals_core/lib/src/persisted/enum.dart
@@ -40,10 +40,10 @@ class PersistedEnumSignal<T extends Enum> extends PersistedSignal<T>
 }
 
 /// A `PersistedSignal` that stores a nullable enum value.
-class PersistedPersistedEnumSignal<T extends Enum> extends PersistedSignal<T?>
+class PersistedNullableEnumSignal<T extends Enum> extends PersistedSignal<T?>
     with _EnumPersistedSignal<T> {
-  /// Creates a new `PersistedEnumSignal`.
-  PersistedPersistedEnumSignal(
+  /// Creates a new `NullableEnumSignal`.
+  PersistedNullableEnumSignal(
     super.val,
     String key,
     this.values, {

--- a/packages/signals_core/test/persisted/signal_test.dart
+++ b/packages/signals_core/test/persisted/signal_test.dart
@@ -50,9 +50,9 @@ void main() {
       });
     });
 
-    group('PersistedPersistedBoolSignal', () {
+    group('PersistedNullableBoolSignal', () {
       test('it should persist a nullable bool value', () async {
-        final signal = PersistedPersistedBoolSignal(true, 'nullable_bool_key');
+        final signal = PersistedNullableBoolSignal(true, 'nullable_bool_key');
         await signal.init();
         expect(signal.value, true);
 
@@ -61,7 +61,7 @@ void main() {
         final item = await store.getItem('nullable_bool_key');
         expect(item, '');
 
-        final signal2 = PersistedPersistedBoolSignal(true, 'nullable_bool_key');
+        final signal2 = PersistedNullableBoolSignal(true, 'nullable_bool_key');
         await signal2.init();
         expect(signal2.value, null);
       });
@@ -122,9 +122,9 @@ void main() {
       });
     });
 
-    group('PersistedPersistedEnumSignal', () {
+    group('PersistedNullableEnumSignal', () {
       test('it should persist a nullable enum value', () async {
-        final signal = PersistedPersistedEnumSignal(
+        final signal = PersistedNullableEnumSignal(
           TestEnum.a,
           'nullable_enum_key',
           TestEnum.values,
@@ -137,7 +137,7 @@ void main() {
         final item = await store.getItem('nullable_enum_key');
         expect(item, '');
 
-        final signal2 = PersistedPersistedEnumSignal(
+        final signal2 = PersistedNullableEnumSignal(
           TestEnum.a,
           'nullable_enum_key',
           TestEnum.values,


### PR DESCRIPTION
The class names PersistedPersistedBoolSignal and PersistedPersistedEnumSignal were incorrectly using a repeated 'Persisted' prefix.

Renamed:
- PersistedPersistedBoolSignal -> PersistedNullableBoolSignal
- PersistedPersistedEnumSignal -> PersistedNullableEnumSignal