### PR TITLE
fix: don't notify signals tracking AsyncSignal.future when transitioning to loading state

### DIFF
--- a/packages/signals_core/lib/src/async/computed.dart
+++ b/packages/signals_core/lib/src/async/computed.dart
@@ -14,6 +14,21 @@ import 'future.dart';
 /// ```
 ///
 /// Since all dependencies are passed in as arguments there is no need to worry about calling the signals before any async gaps with await.
+///
+/// If async signals need to be tracked across an async gap and they are being awaited via their `.future`,
+/// then use their `.completion` for the dependencies rather than the async signal itself.
+/// This way the `computedFrom` will be reset when the tracked signal completes, effectively ignoring their transition into a loading state.
+///
+/// ```dart
+/// final count = asyncSignal(AsyncData(0));
+///
+/// final s = computedFrom([count.completion], (_) async => await count.future);
+///
+/// await s.future; // 0
+/// count.value = AsyncLoading(); // ignored by the computedFrom
+/// count.value = AsyncData(1);
+/// await s.future; // 1
+/// ```
 FutureSignal<T> computedFrom<T, A>(
   List<ReadonlySignal<A>> signals,
   Future<T> Function(List<A> args) fn, {

--- a/packages/signals_core/lib/src/async/future.dart
+++ b/packages/signals_core/lib/src/async/future.dart
@@ -170,6 +170,24 @@ class FutureSignal<T> extends StreamSignal<T> {
   /// count.value = 1; // resets the future
   /// s.value; // state with count 1
   /// ```
+  ///
+  /// If other async signals need to be tracked across an async gap and they are being awaited via their `.future`,
+  /// then use their `.completion` for the dependencies rather than the async signal itself.
+  /// This way the `futureSignal` will be reset when the tracked signal completes, effectively ignoring their transition into a loading state.
+  ///
+  /// ```dart
+  /// final count = asyncSignal(AsyncData(0));
+  ///
+  /// final s = futureSignal(
+  ///     () async => await count.future,
+  ///     dependencies: [count.completion],
+  /// );
+  ///
+  /// await s.future; // 0
+  /// count.value = AsyncLoading(); // ignored by the future signal
+  /// count.value = AsyncData(1);
+  /// await s.future; // 1
+  /// ```
   /// @link https://dartsignals.dev/async/future
   /// {@endtemplate}
   FutureSignal(

--- a/packages/signals_core/lib/src/async/stream.dart
+++ b/packages/signals_core/lib/src/async/stream.dart
@@ -357,6 +357,17 @@ class StreamSignal<T> extends AsyncSignal<T> {
   }
 
   @override
+  Future<T> get future {
+    untracked(() {
+      // make sure the stream is exectuted,
+      // so the returned future will be completed eventually
+      value;
+    });
+
+    return super.future;
+  }
+
+  @override
   void setError(Object error, [StackTrace? stackTrace]) {
     super.setError(error, stackTrace);
     if (cancelOnError == true) {

--- a/packages/signals_core/test/async/future_test.dart
+++ b/packages/signals_core/test/async/future_test.dart
@@ -159,5 +159,462 @@ void main() {
 
       expect(result, 'b0');
     });
+
+    group('.future', () {
+      test('notifies once when signal completes', () async {
+        int calls = 0;
+        int signalCalls = 0;
+        int computedCalls = 0;
+        int heavyComputationCalls = 0;
+
+        final a = signal(10);
+
+        Future<int> future(int value) async {
+          calls++;
+          await Future.delayed(const Duration(milliseconds: 5));
+          return value;
+        }
+
+        final b = futureSignal(
+          () async {
+            signalCalls++;
+            return await future(a.value);
+          },
+          dependencies: [a],
+        );
+
+        Future<int> heavyComputation(int value) async {
+          heavyComputationCalls++;
+          await Future.delayed(const Duration(milliseconds: 5));
+          return value * 2;
+        }
+
+        final c = futureSignal(
+          () async {
+            computedCalls++;
+            final value = await b.future;
+            return await heavyComputation(value);
+          },
+          dependencies: [b.completion],
+        );
+
+        final result = await c.future;
+
+        expect(result, 20, reason: 'unexpected result');
+        expect(calls, 1);
+        expect(signalCalls, 1);
+        expect(heavyComputationCalls, 1);
+        expect(computedCalls, 1);
+
+        a.value = 20;
+
+        final result2 = await c.future;
+
+        expect(result2, 40);
+        expect(calls, 2);
+        expect(signalCalls, 2);
+        expect(heavyComputationCalls, 2);
+        expect(computedCalls, 2);
+      });
+
+      test('notifies once when signal completes (with initial data)', () async {
+        var signalCalls = 0;
+        var computedCalls = 0;
+
+        final a = futureSignal(
+          () async {
+            signalCalls++;
+            await Future.delayed(const Duration(milliseconds: 5));
+            return 42;
+          },
+          initialValue: 21,
+        );
+
+        final b = futureSignal(
+          () async {
+            computedCalls++;
+            return await a.future;
+          },
+        );
+
+        final seenValuesOfA = <AsyncState<int>>[];
+        effect(() {
+          seenValuesOfA.add(a.value);
+        });
+
+        final seenValuesOfB = <AsyncState<int>>[];
+        effect(() {
+          seenValuesOfB.add(b.value);
+        });
+
+        final result = await b.future;
+        expect(result, 42, reason: 'unexpected result');
+
+        expect(seenValuesOfA, hasLength(2));
+        expect(seenValuesOfA[0], AsyncData<int>(21));
+        expect(seenValuesOfA[1], AsyncData<int>(42));
+
+        expect(seenValuesOfB, hasLength(2));
+        expect(seenValuesOfB[0], AsyncLoading<int>());
+        expect(seenValuesOfB[1], AsyncData<int>(42));
+
+        expect(signalCalls, 1);
+        expect(computedCalls, 1);
+      });
+
+      test('error after accessing .future', () async {
+        int invocations = 0;
+        final trigger = signal(0);
+
+        final s = futureSignal(
+          () async {
+            // Track dependency so changes trigger recomputation
+            final t = trigger.value;
+            await Future.delayed(const Duration(milliseconds: 5));
+            invocations++;
+            if (t == 0) {
+              throw Exception('boom');
+            }
+            return 99;
+          },
+          dependencies: [trigger],
+        );
+
+        // First run should error because trigger == 0
+        await expectLater(s.future, throwsA(isA<Exception>()));
+        expect(invocations, 1);
+
+        // Next run should succeed
+        trigger.value = 1;
+        final result = await s.future;
+        expect(result, 99);
+        expect(invocations, 2);
+      });
+
+      test('error before accessing .future', () async {
+        int calls = 0;
+
+        final expectedError = Exception('err-before-use');
+
+        final s = futureSignal(() async {
+          calls++;
+          await Future.delayed(const Duration(milliseconds: 5));
+          throw expectedError;
+        });
+
+        expect(s.peek(), AsyncLoading());
+
+        // Wait for the first (failing) run to finish without ever touching s.future
+        await Future.delayed(const Duration(milliseconds: 20));
+
+        expect(s.peek().error, expectedError);
+
+        // Now access future and trigger a successful recompute
+        await expectLater(s.future, throwsA(expectedError));
+
+        expect(calls, 1);
+      });
+
+      test('.reload notifies completion only once per cycle', () async {
+        int calls = 0;
+        final s = futureSignal(() async {
+          calls++;
+          await Future.delayed(const Duration(milliseconds: 5));
+          return calls;
+        });
+
+        // A computed depending on completion should only recompute when s completes
+        int computedCalls = 0;
+        final c = futureSignal(
+          () async {
+            computedCalls++;
+            final v = await s.future;
+            return v * 10;
+          },
+          dependencies: [s.completion],
+        );
+
+        final first = await c.future;
+        expect(first, 10);
+        expect(calls, 1);
+        expect(computedCalls, 1);
+
+        // Trigger reload — should not notify on AsyncLoading, only once when completed
+        await s.reload();
+        final second = await c.future;
+        expect(second, 20);
+        expect(calls, 2);
+        expect(computedCalls, 2);
+      });
+
+      test('.refresh notifies completion only once per cycle', () async {
+        int calls = 0;
+        final s = futureSignal(() async {
+          calls++;
+          await Future.delayed(const Duration(milliseconds: 5));
+          return calls;
+        });
+
+        int computedCalls = 0;
+        final c = futureSignal(
+          () async {
+            computedCalls++;
+            final v = await s.future;
+            return v * 100;
+          },
+          dependencies: [s.completion],
+        );
+
+        final first = await c.future;
+        expect(first, 100);
+        expect(calls, 1);
+        expect(computedCalls, 1);
+
+        await s.refresh();
+        final second = await c.future;
+        expect(second, 200);
+        expect(calls, 2);
+        expect(computedCalls, 2);
+      });
+
+      test('completes with error', () async {
+        int run = 0;
+        final s = futureSignal(
+          () async {
+            run++;
+            await Future.delayed(const Duration(milliseconds: 5));
+            if (run == 1) return 1; // initial success
+            throw Exception('later failure');
+          },
+          initialValue: 0,
+        );
+
+        // Initial: goes from AsyncData(0) to AsyncData(1)
+        expect(await s.future, 1);
+
+        // Next run should error
+        // Trigger recompute by reloading
+        s.reload().catchError((err, stackTrace) {});
+        await expectLater(s.future, throwsA(isA<Exception>()));
+        expect(run, 2);
+      });
+
+      test('notifies once with latest value', () async {
+        final completer1 = Completer<int>();
+        final completer2 = Completer<int>();
+
+        final source = signal(1);
+
+        final s = futureSignal(() async {
+          return switch (source.value) {
+            1 => await completer1.future,
+            2 => await completer2.future,
+            _ => throw UnimplementedError(),
+          };
+        });
+
+        int calls = 0;
+
+        final c = futureSignal(() async {
+          calls++;
+          return await s.future;
+        });
+
+        final future1 = c.future;
+
+        source.value = 2;
+
+        final future2 = c.future;
+
+        completer2.complete(42);
+
+        await Future.delayed(Duration(milliseconds: 5));
+
+        completer1.complete(21);
+
+        await expectLater(future1, completion(42));
+        await expectLater(future2, completion(42));
+        expect(calls, 1);
+      });
+
+      test('latest-wins: success then newer error', () async {
+        final completer1 = Completer<int>();
+        final completer2 = Completer<int>();
+        // final expectedError = Exception('latest error');
+
+        final source = signal(1);
+
+        final s = futureSignal(() async {
+          return switch (source.value) {
+            1 => await completer1.future, // A (success)
+            2 => await completer2.future, // B (error)
+            _ => throw UnimplementedError(),
+          };
+        });
+
+        int calls = 0;
+        final c = computedFrom([s.completion], (_) async {
+          calls++;
+          return await s.future;
+        });
+
+        final future1 = c.future; // starts A
+        source.value = 2; // start B
+        final future2 = c.future;
+
+        final e1 = expectLater(future1, throwsA('error'));
+        final e2 = expectLater(future2, throwsA('error'));
+
+        // Complete newer B first with error, then complete older A (success) later.
+        completer2.completeError('error');
+        await Future.delayed(const Duration(milliseconds: 5));
+        completer1.complete(21);
+
+        await e1;
+        await e2;
+        expect(calls, 1);
+        expect(s.peek().hasError, isTrue);
+      });
+
+      test('concurrent awaiters share one completion', () async {
+        int calls = 0;
+        final completer = Completer<int>();
+
+        final s = futureSignal(() async {
+          calls++;
+          return await completer.future;
+        });
+
+        // Attach listeners BEFORE completing the underlying future
+        final future1 = s.future;
+        final future2 = s.future;
+        final e1 = expectLater(future1, completion(123));
+        final e2 = expectLater(future2, completion(123));
+
+        completer.complete(123);
+
+        await e1;
+        await e2;
+        expect(calls, 1);
+        expect(s.peek().requireValue, 123);
+      });
+
+      test('latest-wins: success then newer success', () async {
+        final completer1 = Completer<int>();
+        final completer2 = Completer<int>();
+
+        final source = signal(1);
+
+        final s = futureSignal(() async {
+          return switch (source.value) {
+            1 => await completer1.future, // A (success, completes last)
+            2 => await completer2.future, // B (success, completes first)
+            _ => throw UnimplementedError(),
+          };
+        });
+
+        int calls = 0;
+        final c = futureSignal(() async {
+          calls++;
+          return await s.future;
+        }, dependencies: [s.completion]);
+
+        final future1 = c.future; // starts A
+        source.value = 2; // start B
+        final future2 = c.future;
+
+        // Attach listeners BEFORE driving the outcomes
+        final e1 = expectLater(future1, completion(42));
+        final e2 = expectLater(future2, completion(42));
+
+        // Complete newer B first, then older A
+        completer2.complete(42);
+        await Future.delayed(const Duration(milliseconds: 5));
+        completer1.complete(21);
+
+        await e1;
+        await e2;
+        expect(calls, 1);
+        expect(s.peek().requireValue, 42);
+      });
+
+      test('latest-wins: error then newer error', () async {
+        final completer1 = Completer<int>();
+        final completer2 = Completer<int>();
+
+        final source = signal(1);
+
+        final s = futureSignal(() async {
+          return switch (source.value) {
+            1 => await completer1.future, // A (error, completes last)
+            2 => await completer2.future, // B (error, completes first)
+            _ => throw UnimplementedError(),
+          };
+        });
+
+        int calls = 0;
+        final c = futureSignal(() async {
+          calls++;
+          return await s.future;
+        }, dependencies: [s.completion]);
+
+        final future1 = c.future; // starts A
+        source.value = 2; // start B
+        final future2 = c.future;
+
+        // Attach listeners BEFORE driving the outcomes to avoid uncaught errors
+        final e1 = expectLater(future1, throwsA('newer error'));
+        final e2 = expectLater(future2, throwsA('newer error'));
+
+        // Complete newer B with error first, then older A with error
+        completer2.completeError('newer error');
+        await Future.delayed(const Duration(milliseconds: 5));
+        completer1.completeError('older error');
+
+        await e1;
+        await e2;
+        expect(calls, 1);
+        expect(s.peek().hasError, isTrue);
+      });
+
+      test('latest-wins: error then newer success', () async {
+        final completer1 = Completer<int>();
+        final completer2 = Completer<int>();
+
+        final source = signal(1);
+
+        final s = futureSignal(() async {
+          return switch (source.value) {
+            1 => await completer1.future, // A (error, completes last)
+            2 => await completer2.future, // B (success, completes first)
+            _ => throw UnimplementedError(),
+          };
+        });
+
+        int calls = 0;
+        final c = futureSignal(() async {
+          calls++;
+          return await s.future;
+        }, dependencies: [s.completion]);
+
+        final future1 = c.future; // starts A
+        source.value = 2; // start B
+        final future2 = c.future;
+
+        // Attach listeners BEFORE driving the outcomes to avoid uncaught errors
+        final e1 = expectLater(future1, completion(42));
+        final e2 = expectLater(future2, completion(42));
+
+        // Complete newer B with success first, then older A with error
+        completer2.complete(42);
+        await Future.delayed(const Duration(milliseconds: 5));
+        completer1.completeError('old error');
+
+        await e1;
+        await e2;
+        expect(calls, 1);
+        expect(s.peek().requireValue, 42);
+      });
+    });
   });
 }


### PR DESCRIPTION
Fixes #433

- Fixes `AsyncSignal.future` to no longer notify when the async signal transitions into a loading state. The notification now happens when the async signal completes with data or error.
- Adds `AsyncSignal.completion` for tracking dependencies across async gaps without getting notified about state changes to loading states.