### PR TITLE
Fix: call super.dispose in SignalHookState

### DIFF
--- a/packages/signals_hooks/lib/src/base.dart
+++ b/packages/signals_hooks/lib/src/base.dart
@@ -24,6 +24,7 @@ class SignalHookState<T, S extends ReadonlySignal<T>>
   @override
   void dispose() {
     _cleanup?.call();
+    super.dispose();
   }
 
   void _listener() {


### PR DESCRIPTION
This PR just fixes a memory leak in the signal_hooks package.