### PR TITLE
feat: Add signals_nocterm package for Nocterm TUI framework integration

### DIFF
--- a/packages/signals_nocterm/README.md
+++ b/packages/signals_nocterm/README.md
@@ -1,0 +1,165 @@
+# Signals Nocterm
+
+Reactive state management for [Nocterm](https://nocterm.dev) terminal UIs using [Signals](https://dartsignals.dev).
+
+## Features
+
+- **SignalsMixin** - Mixin for `State` classes to automatically manage signal lifecycle
+- **Watch** - Component for fine-grained rebuilds
+- **WatchBuilder** - Builder pattern for watching a single signal
+- **watchSignal** - Function to watch signals in any build method
+
+## Installation
+
+```yaml
+dependencies:
+  signals_nocterm: ^0.1.0
+```
+
+## Quick Start
+
+### Using SignalsMixin
+
+The most common way to use signals in Nocterm is with the `SignalsMixin`:
+
+```dart
+import 'package:nocterm/nocterm.dart';
+import 'package:signals_nocterm/signals_nocterm.dart';
+
+class Counter extends StatefulComponent {
+  const Counter({super.key});
+
+  @override
+  State<Counter> createState() => _CounterState();
+}
+
+class _CounterState extends State<Counter> with SignalsMixin {
+  // Create signals - they're automatically disposed
+  late final _count = createSignal(0);
+  late final _doubled = createComputed(() => _count() * 2);
+
+  @override
+  void initState() {
+    super.initState();
+    // Create effects - also automatically disposed
+    createEffect(() {
+      print('Count: ${_count()}, Doubled: ${_doubled()}');
+    });
+  }
+
+  @override
+  Component build(BuildContext context) {
+    return Focusable(
+      focused: true,
+      onKeyEvent: (event) {
+        if (event.logicalKey == LogicalKey.space) {
+          _count.value++;
+          return true;
+        }
+        return false;
+      },
+      child: Center(
+        child: Text('Count: ${_count()}, Doubled: ${_doubled()}'),
+      ),
+    );
+  }
+}
+```
+
+### Using Watch for Fine-Grained Rebuilds
+
+Use `Watch` to only rebuild specific parts of your component tree:
+
+```dart
+final count = signal(0);
+
+class MyComponent extends StatelessComponent {
+  const MyComponent({super.key});
+
+  @override
+  Component build(BuildContext context) {
+    return Column(
+      children: [
+        // Only this part rebuilds when count changes
+        Watch((context) => Text('Count: ${count()}')),
+        // This part never rebuilds
+        const Text('Static text'),
+      ],
+    );
+  }
+}
+```
+
+### Using WatchBuilder
+
+`WatchBuilder` provides a builder pattern for watching a single signal:
+
+```dart
+final count = signal(0);
+
+WatchBuilder<int>(
+  signal: count,
+  builder: (context, value, child) {
+    return Text('Count: $value');
+  },
+  // Optional child that doesn't rebuild
+  child: const Text('Static child'),
+)
+```
+
+### Using watchSignal Extension
+
+You can also use the `watch` extension on any signal:
+
+```dart
+class MyComponent extends StatelessComponent {
+  final count = signal(0);
+
+  @override
+  Component build(BuildContext context) {
+    // This component rebuilds when count changes
+    final value = count.watch(context);
+    return Text('Count: $value');
+  }
+}
+```
+
+## API Reference
+
+### SignalsMixin
+
+Methods available when using `SignalsMixin`:
+
+| Method | Description |
+|--------|-------------|
+| `createSignal<T>(value)` | Create a signal that's automatically disposed |
+| `createComputed<T>(fn)` | Create a computed signal |
+| `createEffect(fn)` | Create an effect that's automatically disposed |
+| `createListSignal<T>(list)` | Create a list signal |
+| `createMapSignal<K,V>(map)` | Create a map signal |
+| `createSetSignal<T>(set)` | Create a set signal |
+| `createFutureSignal<T>(fn)` | Create a future-based signal |
+| `createStreamSignal<T>(fn)` | Create a stream-based signal |
+| `bindSignal(signal)` | Watch an external signal |
+| `unbindSignal(signal)` | Stop watching a signal |
+| `watchSignal(signal)` | Get value and watch signal |
+| `listenSignal(signal, callback)` | Listen to signal changes |
+| `disposeSignal(id)` | Manually dispose a signal |
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `Watch` | Rebuilds its child when any accessed signal changes |
+| `WatchBuilder<T>` | Builder pattern for a single signal |
+
+### Functions
+
+| Function | Description |
+|----------|-------------|
+| `watchSignal<T>(context, signal)` | Watch a signal in any build method |
+| `unwatchSignal<T>(context, signal)` | Stop watching a signal |
+
+## License
+
+MIT

--- a/packages/signals_nocterm/example/counter.dart
+++ b/packages/signals_nocterm/example/counter.dart
@@ -1,0 +1,76 @@
+import 'package:nocterm/nocterm.dart';
+import 'package:signals_nocterm/signals_nocterm.dart';
+
+void main() {
+  runApp(const Counter());
+}
+
+/// A simple counter example using signals.
+///
+/// Press SPACE to increment the counter.
+/// Press 'r' to reset the counter.
+class Counter extends StatefulComponent {
+  const Counter({super.key});
+
+  @override
+  State<Counter> createState() => _CounterState();
+}
+
+class _CounterState extends State<Counter> with SignalsMixin {
+  // Create a signal for the count
+  late final _count = createSignal(0);
+
+  // Create a computed signal for the doubled value
+  late final _doubled = createComputed(() => _count() * 2);
+
+  // Create a computed signal for checking if even
+  late final _isEven = createComputed(() => _count() % 2 == 0);
+
+  @override
+  void initState() {
+    super.initState();
+
+    // Create an effect that logs when count changes
+    createEffect(() {
+      print('Count changed to: ${_count()}');
+    });
+  }
+
+  @override
+  Component build(BuildContext context) {
+    return Focusable(
+      focused: true,
+      onKeyEvent: (event) {
+        if (event.logicalKey == LogicalKey.space) {
+          _count.value++;
+          return true;
+        }
+        if (event.character == 'r') {
+          _count.value = 0;
+          return true;
+        }
+        if (event.logicalKey == LogicalKey.escape) {
+          shutdownApp();
+          return true;
+        }
+        return false;
+      },
+      child: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text('Signals + Nocterm Counter'),
+            const Text(''),
+            Text('Count: ${_count()}'),
+            Text('Doubled: ${_doubled()}'),
+            Text('Is Even: ${_isEven()}'),
+            const Text(''),
+            const Text('Press SPACE to increment'),
+            const Text('Press R to reset'),
+            const Text('Press ESC to quit'),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/packages/signals_nocterm/lib/signals_core.dart
+++ b/packages/signals_nocterm/lib/signals_core.dart
@@ -1,0 +1,4 @@
+/// Re-export signals_core for convenience.
+library;
+
+export 'package:signals_core/signals_core.dart';

--- a/packages/signals_nocterm/lib/signals_nocterm.dart
+++ b/packages/signals_nocterm/lib/signals_nocterm.dart
@@ -1,0 +1,78 @@
+/// Signals integration for Nocterm - reactive state management for terminal UIs.
+///
+/// This library provides seamless integration between the signals reactive
+/// programming library and Nocterm's terminal UI framework.
+///
+/// ## Getting Started
+///
+/// Add signals_nocterm to your pubspec.yaml:
+///
+/// ```yaml
+/// dependencies:
+///   signals_nocterm: ^0.1.0
+/// ```
+///
+/// ## Usage with SignalsMixin
+///
+/// Use [SignalsMixin] with your [State] class to automatically manage signals:
+///
+/// ```dart
+/// class Counter extends StatefulComponent {
+///   const Counter({super.key});
+///
+///   @override
+///   State<Counter> createState() => _CounterState();
+/// }
+///
+/// class _CounterState extends State<Counter> with SignalsMixin {
+///   late final _count = createSignal(0);
+///   late final _doubled = createComputed(() => _count() * 2);
+///
+///   @override
+///   void initState() {
+///     super.initState();
+///     createEffect(() {
+///       print('Count: ${_count()}, Doubled: ${_doubled()}');
+///     });
+///   }
+///
+///   @override
+///   Component build(BuildContext context) {
+///     return Center(
+///       child: Text('Count: ${_count()}, Doubled: ${_doubled()}'),
+///     );
+///   }
+/// }
+/// ```
+///
+/// ## Usage with Watch
+///
+/// Use [Watch] component or [watchSignal] function for fine-grained rebuilds:
+///
+/// ```dart
+/// class MyComponent extends StatelessComponent {
+///   MyComponent({super.key});
+///
+///   final count = signal(0);
+///
+///   @override
+///   Component build(BuildContext context) {
+///     return Watch((context) => Text('Count: ${count()}'));
+///   }
+/// }
+/// ```
+///
+/// Or use [watchSignal] in your build method:
+///
+/// ```dart
+/// @override
+/// Component build(BuildContext context) {
+///   final value = watchSignal(context, mySignal);
+///   return Text('Value: $value');
+/// }
+/// ```
+library;
+
+export 'signals_core.dart';
+export 'src/mixins/signals.dart';
+export 'src/watch/watch.dart';

--- a/packages/signals_nocterm/lib/src/mixins/signals.dart
+++ b/packages/signals_nocterm/lib/src/mixins/signals.dart
@@ -1,0 +1,419 @@
+import 'dart:async';
+import 'dart:collection';
+
+import 'package:nocterm/nocterm.dart';
+import 'package:signals_core/signals_core.dart';
+
+typedef _SignalMetadata = ({
+  bool? local,
+  ReadonlySignal<dynamic> target,
+  ({Function cb, EffectCleanup cleanup})? listener,
+});
+
+/// Signals mixin that will automatically rebuild the component tree when any of
+/// the signals change and dispose of any signals and effects created locally.
+///
+/// ## Example
+///
+/// ```dart
+/// class MyComponent extends StatefulComponent {
+///   const MyComponent({super.key});
+///
+///   @override
+///   State<MyComponent> createState() => _MyComponentState();
+/// }
+///
+/// class _MyComponentState extends State<MyComponent> with SignalsMixin {
+///   late final _signal = createSignal(0);
+///   late final _computed = createComputed(() => _signal() * 2);
+///
+///   @override
+///   void initState() {
+///     super.initState();
+///     createEffect(() {
+///       print('count: $_signal, double: $_computed');
+///     });
+///   }
+///
+///   @override
+///   Component build(BuildContext context) {
+///     return Text('Count: ${_signal()}, Doubled: ${_computed()}');
+///   }
+/// }
+/// ```
+mixin SignalsMixin<T extends StatefulComponent> on State<T> {
+  final _signals = HashMap.of(<int, _SignalMetadata>{});
+  EffectCleanup? _cleanup;
+  final _effects = <EffectCleanup>[];
+
+  /// Dispose and remove signal
+  void disposeSignal(int id) {
+    final s = _signals.remove(id);
+    if (s == null) return;
+    s.target.dispose();
+    s.listener?.cleanup();
+  }
+
+  Future<void> _rebuild() async {
+    if (!mounted) return;
+
+    final scheduler = SchedulerBinding.instance;
+    if (scheduler.schedulerPhase != SchedulerPhase.idle) {
+      await scheduler.endOfFrame;
+      if (!mounted) return;
+    }
+
+    setState(() {});
+    return;
+  }
+
+  void _setup() {
+    SchedulerBinding.instance.addPostFrameCallback((_) {
+      final cb = effect(() {
+        // Snapshot to prevent ConcurrentModificationError if value access
+        // triggers bindSignal() which mutates _signals during iteration
+        final signals = _signals.values.where((e) => e.local != null).toList();
+        for (final s in signals) {
+          s.target.value;
+        }
+        _rebuild();
+      });
+      _cleanup?.call();
+      _cleanup = cb;
+    });
+  }
+
+  void _watch(ReadonlySignal<dynamic> target, bool local) {
+    if (_signals[target.globalId]?.local != null) {
+      return;
+    }
+    final listener = _signals[target.globalId]?.listener;
+    _signals[target.globalId] = (
+      local: local,
+      target: target,
+      listener: listener,
+    );
+    _setup();
+  }
+
+  void _unwatch(ReadonlySignal<dynamic> target) {
+    if (!_signals.containsKey(target.globalId)) return;
+    final listener = _signals[target.globalId]?.listener;
+    _signals[target.globalId] = (
+      local: null,
+      target: target,
+      listener: listener,
+    );
+    _setup();
+  }
+
+  /// Async Computed is syntax sugar around [FutureSignal].
+  ///
+  /// _Inspired by [computedFrom](https://ngxtension.netlify.app/utilities/signals/computed-from/) from Angular NgExtension._
+  ///
+  /// computedFrom takes a list of [signals] and a [callback] function to
+  /// compute the value of the signal every time one of the [signals] changes.
+  ///
+  /// ```dart
+  /// final movieId = signal('id');
+  /// late final movie = computedFrom(args, ([movieId]) => fetchMovie(args.first));
+  /// ```
+  ///
+  /// Since all dependencies are passed in as arguments there is no need to worry about calling the signals before any async gaps with await.
+  FutureSignal<S> createComputedFrom<S, A>(
+    List<ReadonlySignal<A>> signals,
+    Future<S> Function(List<A> args) fn, {
+    S? initialValue,
+    String? debugLabel,
+    bool lazy = true,
+  }) {
+    return _bindLocal(
+      computedFrom<S, A>(
+        signals,
+        fn,
+        initialValue: initialValue,
+        debugLabel: debugLabel,
+        lazy: lazy,
+      ),
+    );
+  }
+
+  /// Async Computed is syntax sugar around [FutureSignal].
+  ///
+  /// _Inspired by [computedAsync](https://ngxtension.netlify.app/utilities/signals/computed-async/) from Angular NgExtension._
+  ///
+  /// computedAsync takes a [callback] function to compute the value
+  /// of the signal. This callback is converted into a [Computed] signal.
+  ///
+  /// ```dart
+  /// final movieId = signal('id');
+  /// late final movie = computedAsync(() => fetchMovie(movieId()));
+  /// ```
+  ///
+  /// **It is important that signals are called before any async gaps with await.**
+  ///
+  /// Any signal that is read inside the callback will be tracked as a dependency and the computed signal will be re-evaluated when any of the dependencies change.
+  FutureSignal<S> createComputedAsync<S>(
+    Future<S> Function() fn, {
+    S? initialValue,
+    String? debugLabel,
+    List<ReadonlySignal<dynamic>> dependencies = const [],
+    bool lazy = true,
+  }) {
+    return _bindLocal(
+      computedAsync<S>(
+        fn,
+        dependencies: dependencies,
+        initialValue: initialValue,
+        debugLabel: debugLabel,
+        lazy: lazy,
+      ),
+    );
+  }
+
+  /// Create a signal from a future
+  FutureSignal<S> createFutureSignal<S>(
+    Future<S> Function() fn, {
+    S? initialValue,
+    String? debugLabel,
+    List<ReadonlySignal<dynamic>> dependencies = const [],
+    bool lazy = true,
+  }) {
+    return _bindLocal(
+      futureSignal<S>(
+        fn,
+        initialValue: initialValue,
+        debugLabel: debugLabel,
+        dependencies: dependencies,
+        lazy: lazy,
+      ),
+    );
+  }
+
+  /// Create a signals from a stream
+  StreamSignal<S> createStreamSignal<S>(
+    Stream<S> Function() callback, {
+    S? initialValue,
+    String? debugLabel,
+    List<ReadonlySignal<dynamic>> dependencies = const [],
+    void Function()? onDone,
+    bool? cancelOnError,
+    bool lazy = true,
+  }) {
+    return _bindLocal(
+      streamSignal<S>(
+        callback,
+        initialValue: initialValue,
+        debugLabel: debugLabel,
+        dependencies: dependencies,
+        onDone: onDone,
+        cancelOnError: cancelOnError,
+        lazy: lazy,
+      ),
+    );
+  }
+
+  /// Create a signal holding an async value
+  AsyncSignal<S> createAsyncSignal<S>(
+    AsyncState<S> value, {
+    String? debugLabel,
+  }) {
+    return _bindLocal(
+      asyncSignal<S>(
+        value,
+        debugLabel: debugLabel,
+      ),
+    );
+  }
+
+  /// Create a signal<T> and watch for changes
+  Signal<V> createSignal<V>(
+    V val, {
+    String? debugLabel,
+  }) {
+    return _bindLocal(
+      signal<V>(
+        val,
+        debugLabel: debugLabel,
+      ),
+    );
+  }
+
+  /// Create a [ListSignal]<T> and watch for changes
+  ListSignal<V> createListSignal<V>(
+    List<V> list, {
+    String? debugLabel,
+  }) {
+    return _bindLocal(
+      ListSignal<V>(
+        list,
+        debugLabel: debugLabel,
+      ),
+    );
+  }
+
+  /// Create a [SetSignal]<T> and watch for changes
+  SetSignal<V> createSetSignal<V>(
+    Set<V> set, {
+    String? debugLabel,
+  }) {
+    return _bindLocal(
+      SetSignal<V>(
+        set,
+        debugLabel: debugLabel,
+      ),
+    );
+  }
+
+  /// Create a [QueueSignal]<T> and watch for changes
+  QueueSignal<V> createQueueSignal<V>(
+    Queue<V> queue, {
+    String? debugLabel,
+  }) {
+    return _bindLocal(
+      QueueSignal<V>(
+        queue,
+        debugLabel: debugLabel,
+      ),
+    );
+  }
+
+  /// Create a [MapSignal]<T> and watch for changes
+  MapSignal<K, V> createMapSignal<K, V>(
+    Map<K, V> value, {
+    String? debugLabel,
+  }) {
+    return _bindLocal(
+      MapSignal<K, V>(
+        value,
+        debugLabel: debugLabel,
+      ),
+    );
+  }
+
+  /// Create a computed<T> and watch for changes
+  Computed<V> createComputed<V>(
+    V Function() cb, {
+    String? debugLabel,
+  }) {
+    return _bindLocal(
+      computed<V>(
+        cb,
+        debugLabel: debugLabel,
+      ),
+    );
+  }
+
+  S _bindLocal<V, S extends ReadonlySignal<V>>(S val) {
+    _watch(val, true);
+    return val;
+  }
+
+  /// Bind an existing signal<T> and watch for changes
+  S bindSignal<V, S extends ReadonlySignal<V>>(S val) {
+    _watch(val, false);
+    return val;
+  }
+
+  /// Unbind an existing signal<T> changes
+  S unbindSignal<V, S extends ReadonlySignal<V>>(S val) {
+    _unwatch(val);
+    return val;
+  }
+
+  /// Watch signal value
+  V watchSignal<V, S extends ReadonlySignal<V>>(S val) {
+    return bindSignal(val).value;
+  }
+
+  /// Unwatch an existing signal<T> value changes
+  V unwatchSignal<V, S extends ReadonlySignal<V>>(S val) {
+    return unbindSignal(val).value;
+  }
+
+  /// Watch signal value
+  void listenSignal(
+    ReadonlySignal<dynamic> target,
+    void Function() callback, {
+    String? debugLabel,
+  }) {
+    final current = _signals[target.globalId];
+    if (current?.listener?.cb.hashCode == callback.hashCode) return;
+    current?.listener?.cleanup();
+    final cb = createEffect(
+      callback,
+      debugLabel: debugLabel,
+    );
+    _signals[target.globalId] = (
+      local: current?.local,
+      target: target,
+      listener: (cb: callback, cleanup: cb),
+    );
+  }
+
+  /// Stop listening to a signal value
+  void unlistenSignal(
+    ReadonlySignal<dynamic> target,
+    void Function() callback,
+  ) {
+    final current = _signals[target.globalId];
+    if (current != null) {
+      current.listener?.cleanup();
+      _signals[target.globalId] = (
+        local: current.local,
+        target: target,
+        listener: null,
+      );
+    }
+  }
+
+  /// Create a effect.
+  ///
+  /// Do not call inside the build method.
+  ///
+  /// Calling this method in build() will create a new
+  /// effect every render.
+  EffectCleanup createEffect(
+    dynamic Function() cb, {
+    String? debugLabel,
+    dynamic Function()? onDispose,
+  }) {
+    final s = effect(
+      cb,
+      debugLabel: debugLabel,
+      onDispose: onDispose,
+    );
+    _effects.add(s);
+    return () {
+      _effects.remove(s);
+      s();
+    };
+  }
+
+  /// Reset all stored signals and effects
+  void clearSignalsAndEffects() {
+    _cleanup?.call();
+    _cleanup = null;
+    // Snapshot collections to prevent ConcurrentModificationError
+    // dispose() and effect cleanup can trigger mutations
+    final local = _signals.values
+        .where((e) => e.local == true)
+        .map((e) => e.target)
+        .toList();
+    for (final s in local) {
+      s.dispose();
+    }
+    final effects = List<EffectCleanup>.of(_effects);
+    for (final cb in effects) {
+      cb();
+    }
+    _effects.clear();
+    _signals.clear();
+  }
+
+  @override
+  void dispose() {
+    clearSignalsAndEffects();
+    super.dispose();
+  }
+}

--- a/packages/signals_nocterm/lib/src/watch/component.dart
+++ b/packages/signals_nocterm/lib/src/watch/component.dart
@@ -1,0 +1,198 @@
+part of 'watch.dart';
+
+/// A component that rebuilds when any signal it depends on changes.
+///
+/// Use this component for fine-grained rebuilds. Only the subtree inside
+/// the [Watch] component will rebuild when a signal changes.
+///
+/// ## Example
+///
+/// ```dart
+/// final count = signal(0);
+///
+/// class MyComponent extends StatelessComponent {
+///   const MyComponent({super.key});
+///
+///   @override
+///   Component build(BuildContext context) {
+///     return Column(
+///       children: [
+///         // Only this part rebuilds when count changes
+///         Watch((context) => Text('Count: ${count()}')),
+///         // This part never rebuilds
+///         Text('Static text'),
+///       ],
+///     );
+///   }
+/// }
+/// ```
+class Watch extends StatefulComponent {
+  /// Creates a [Watch] component.
+  const Watch(
+    this.builder, {
+    super.key,
+  });
+
+  /// The builder function that returns the component tree.
+  ///
+  /// This function is called whenever any signal accessed inside it changes.
+  final Component Function(BuildContext context) builder;
+
+  @override
+  State<Watch> createState() => _WatchState();
+}
+
+class _WatchState extends State<Watch> {
+  core.EffectCleanup? _cleanup;
+  Component? _child;
+
+  @override
+  void initState() {
+    super.initState();
+    _rebuild();
+  }
+
+  @override
+  void didUpdateComponent(Watch oldComponent) {
+    super.didUpdateComponent(oldComponent);
+    if (oldComponent.builder != component.builder) {
+      _rebuild();
+    }
+  }
+
+  void _rebuild() {
+    _cleanup?.call();
+    _cleanup = core.effect(() {
+      final child = component.builder(context);
+      if (_child != child) {
+        _child = child;
+        _scheduleRebuild();
+      }
+    });
+  }
+
+  void _scheduleRebuild() async {
+    if (!mounted) return;
+
+    final scheduler = SchedulerBinding.instance;
+    if (scheduler.schedulerPhase != SchedulerPhase.idle) {
+      await scheduler.endOfFrame;
+      if (!mounted) return;
+    }
+
+    setState(() {});
+  }
+
+  @override
+  void dispose() {
+    _cleanup?.call();
+    _cleanup = null;
+    super.dispose();
+  }
+
+  @override
+  Component build(BuildContext context) {
+    return _child ?? const SizedBox.shrink();
+  }
+}
+
+/// A builder component that rebuilds when any signal it depends on changes.
+///
+/// This is an alternative to [Watch] that provides access to the current
+/// signal value through a callback pattern.
+///
+/// ## Example
+///
+/// ```dart
+/// final count = signal(0);
+///
+/// WatchBuilder<int>(
+///   signal: count,
+///   builder: (context, value, child) {
+///     return Text('Count: $value');
+///   },
+/// )
+/// ```
+class WatchBuilder<T> extends StatefulComponent {
+  /// Creates a [WatchBuilder] component.
+  const WatchBuilder({
+    super.key,
+    required this.signal,
+    required this.builder,
+    this.child,
+  });
+
+  /// The signal to watch.
+  final core.ReadonlySignal<T> signal;
+
+  /// The builder function that returns the component tree.
+  final Component Function(BuildContext context, T value, Component? child)
+      builder;
+
+  /// An optional child component that doesn't depend on the signal.
+  ///
+  /// This child is passed to the builder and won't be rebuilt when
+  /// the signal changes.
+  final Component? child;
+
+  @override
+  State<WatchBuilder<T>> createState() => _WatchBuilderState<T>();
+}
+
+class _WatchBuilderState<T> extends State<WatchBuilder<T>> {
+  VoidCallback? _cleanup;
+  late T _value;
+
+  @override
+  void initState() {
+    super.initState();
+    _value = component.signal.value;
+    _subscribe();
+  }
+
+  @override
+  void didUpdateComponent(WatchBuilder<T> oldComponent) {
+    super.didUpdateComponent(oldComponent);
+    if (oldComponent.signal != component.signal) {
+      _unsubscribe();
+      _value = component.signal.value;
+      _subscribe();
+    }
+  }
+
+  void _subscribe() {
+    _cleanup = component.signal.subscribe((value) {
+      _scheduleRebuild(value);
+    });
+  }
+
+  void _unsubscribe() {
+    _cleanup?.call();
+    _cleanup = null;
+  }
+
+  void _scheduleRebuild(T value) async {
+    if (!mounted) return;
+
+    final scheduler = SchedulerBinding.instance;
+    if (scheduler.schedulerPhase != SchedulerPhase.idle) {
+      await scheduler.endOfFrame;
+      if (!mounted) return;
+    }
+
+    setState(() {
+      _value = value;
+    });
+  }
+
+  @override
+  void dispose() {
+    _unsubscribe();
+    super.dispose();
+  }
+
+  @override
+  Component build(BuildContext context) {
+    return component.builder(context, _value, component.child);
+  }
+}

--- a/packages/signals_nocterm/lib/src/watch/element_watcher.dart
+++ b/packages/signals_nocterm/lib/src/watch/element_watcher.dart
@@ -1,0 +1,124 @@
+part of 'watch.dart';
+
+// coverage:ignore-start
+final _elementRefs = <int, ElementWatcher>{};
+bool _removing = false;
+
+void _removeSignalWatchers() {
+  if (_removing) return;
+  _removing = true;
+  SchedulerBinding.instance.addPostFrameCallback((timeStamp) {
+    _elementRefs.removeWhere((key, value) => value.element.target == null);
+    _removing = false;
+  });
+}
+
+/// Helper class to track signals and effects
+/// with the lifecycle of an element.
+@visibleForTesting
+class ElementWatcher {
+  /// Helper class to track signals and effects
+  /// with the lifecycle of an element.
+  ElementWatcher(this.id, this.label, this.element);
+
+  /// Get [ElementWatcher] for a given signal id
+  static ElementWatcher? get(int id) => _elementRefs[id];
+
+  /// Unique id to store with the element
+  final int id;
+
+  /// Internal label used to track the current component
+  final String label;
+
+  /// Nocterm element that is usually a component
+  final WeakReference<Element> element;
+
+  final _watch = <int, VoidCallback>{};
+  final _listen = <int, VoidCallback>{};
+  final _batch = <VoidCallback>{};
+
+  /// Check if the watcher is active via non empty listeners.
+  bool get active {
+    return _watch.isNotEmpty || _listen.isNotEmpty;
+  }
+
+  /// Watch a signal on an element
+  void watch(core.ReadonlySignal value) {
+    _watch.putIfAbsent(
+      value.globalId,
+      () => value.subscribe((val) => rebuild()),
+    );
+  }
+
+  /// Remove the listener of an element for a given signal
+  void unwatch(core.ReadonlySignal value) {
+    final dispose = _watch.remove(value.globalId);
+    dispose?.call();
+  }
+
+  /// Attach a callback to the component
+  void listen(core.ReadonlySignal value, VoidCallback cb) {
+    _listen.putIfAbsent(
+      value.globalId,
+      () => value.subscribe((val) => _callback(cb, listener: true)),
+    );
+  }
+
+  /// Stop calling the callback for a signal
+  void unlisten(core.ReadonlySignal value, VoidCallback cb) {
+    final dispose = _listen.remove(value.globalId);
+    dispose?.call();
+  }
+
+  /// Rebuild the component
+  void rebuild() async {
+    final target = element.target;
+    if (target == null) {
+      dispose();
+      return;
+    }
+    if (!target.mounted) return;
+
+    final scheduler = SchedulerBinding.instance;
+    if (scheduler.schedulerPhase != SchedulerPhase.idle) {
+      await scheduler.endOfFrame;
+      if (!target.mounted) return;
+    }
+    target.markNeedsBuild();
+  }
+
+  void _callback(VoidCallback cb, {bool listener = false}) async {
+    final target = element.target;
+    if (target == null) {
+      dispose();
+      return;
+    }
+    if (listener) {
+      cb();
+    } else {
+      if (!target.mounted) return;
+      if (_batch.contains(cb)) return;
+      _batch.add(cb);
+      _call();
+    }
+  }
+
+  void _call() {
+    for (final cb in _batch) {
+      cb();
+    }
+    _batch.clear();
+  }
+
+  /// Dispose of the element watcher and all the listeners
+  void dispose() {
+    for (final cleanup in _watch.values) {
+      cleanup();
+    }
+    for (final cleanup in _listen.values) {
+      cleanup();
+    }
+    _removeSignalWatchers();
+  }
+}
+// coverage:ignore-end

--- a/packages/signals_nocterm/lib/src/watch/element_watcher.dart
+++ b/packages/signals_nocterm/lib/src/watch/element_watcher.dart
@@ -112,10 +112,16 @@ class ElementWatcher {
 
   /// Dispose of the element watcher and all the listeners
   void dispose() {
-    for (final cleanup in _watch.values) {
+    // Snapshot the values to prevent ConcurrentModificationError
+    // if cleanup callbacks trigger signal updates that modify the maps
+    final watchCleanups = List<VoidCallback>.of(_watch.values);
+    final listenCleanups = List<VoidCallback>.of(_listen.values);
+    _watch.clear();
+    _listen.clear();
+    for (final cleanup in watchCleanups) {
       cleanup();
     }
-    for (final cleanup in _listen.values) {
+    for (final cleanup in listenCleanups) {
       cleanup();
     }
     _removeSignalWatchers();

--- a/packages/signals_nocterm/lib/src/watch/extension.dart
+++ b/packages/signals_nocterm/lib/src/watch/extension.dart
@@ -1,0 +1,76 @@
+part of 'watch.dart';
+
+/// Watch a signal value and rebuild the context of the [Element]
+/// if mounted and mark it as dirty
+T watchSignal<T>(
+  BuildContext context,
+  core.ReadonlySignal<T> signal, {
+  String? debugLabel,
+}) {
+  final ctx = context;
+  if (ctx.component is Watch) return signal.value;
+  if (ctx is StatefulElement) {
+    final state = ctx.state;
+    if (state is SignalsMixin) {
+      return state.watchSignal(signal);
+    }
+  }
+  if (ctx is Element) {
+    final key = identityHashCode(ctx);
+    if (_elementRefs[key] == null) {
+      final label = [
+        'component',
+        ctx.component.runtimeType.toString(),
+        identityHashCode(ctx.component).toString(),
+      ].join('=');
+      final watcher = ElementWatcher(
+        key,
+        label,
+        WeakReference(ctx),
+      );
+      _elementRefs[key] = watcher;
+      _removeSignalWatchers();
+    }
+    _elementRefs[key]?.watch(signal);
+  }
+  // Grab the current value without subscribing
+  return signal.peek();
+}
+
+/// Remove all subscribers for a given signal for watchers
+void unwatchSignal<T>(BuildContext context, core.ReadonlySignal<T> signal) {
+  final ctx = context;
+  if (ctx.component is Watch) return;
+  if (ctx is StatefulElement) {
+    final state = ctx.state;
+    if (state is SignalsMixin) {
+      return state.unwatchSignal(signal);
+    }
+  }
+  final key = identityHashCode(ctx);
+  _elementRefs.remove(key)?.unwatch(signal);
+}
+
+/// Extension on [core.ReadonlySignal] to provide [watch] and [unwatch] methods.
+extension SignalWatchExtension<T> on core.ReadonlySignal<T> {
+  /// Watch a signal value and rebuild the context of the [Element]
+  /// if mounted and mark it as dirty.
+  ///
+  /// ```dart
+  /// final count = signal(0);
+  ///
+  /// @override
+  /// Component build(BuildContext context) {
+  ///   final value = count.watch(context);
+  ///   return Text('Count: $value');
+  /// }
+  /// ```
+  T watch(BuildContext context, {String? debugLabel}) {
+    return watchSignal(context, this, debugLabel: debugLabel);
+  }
+
+  /// Unwatch a signal value and stop rebuilding the context.
+  void unwatch(BuildContext context) {
+    unwatchSignal(context, this);
+  }
+}

--- a/packages/signals_nocterm/lib/src/watch/watch.dart
+++ b/packages/signals_nocterm/lib/src/watch/watch.dart
@@ -1,0 +1,9 @@
+import 'package:meta/meta.dart';
+import 'package:nocterm/nocterm.dart';
+import 'package:signals_core/signals_core.dart' as core;
+
+import '../mixins/signals.dart';
+
+part 'element_watcher.dart';
+part 'extension.dart';
+part 'component.dart';

--- a/packages/signals_nocterm/pubspec.yaml
+++ b/packages/signals_nocterm/pubspec.yaml
@@ -1,0 +1,27 @@
+name: signals_nocterm
+description: Signals integration for Nocterm - reactive state management for terminal UIs.
+version: 0.1.0
+repository: https://github.com/rodydavis/signals.dart
+homepage: https://dartsignals.dev/
+documentation: https://dartsignals.dev/
+
+environment:
+  sdk: ^3.5.0
+
+resolution: workspace
+
+dependencies:
+  nocterm: ^0.4.4
+  signals_core: ^6.2.1
+
+dev_dependencies:
+  test: ^1.25.6
+  lints: ^5.0.0
+
+topics:
+  - signal
+  - reactive
+  - state
+  - signals
+  - nocterm
+  - tui

--- a/packages/signals_nocterm/test/signals_nocterm_test.dart
+++ b/packages/signals_nocterm/test/signals_nocterm_test.dart
@@ -27,6 +27,34 @@ void main() {
 
       expect(tester.terminalState, containsText('Count: 1, Doubled: 2'));
     });
+
+    testNocterm('should dispose signals when component unmounts', (tester) async {
+      final count = signal(0);
+      var disposed = false;
+
+      // Track when the signal is disposed
+      count.onDispose(() => disposed = true);
+
+      await tester.pumpComponent(_TestCounter(count: count));
+      expect(disposed, isFalse);
+
+      // Replace with a different component to unmount
+      await tester.pumpComponent(const Text('Replaced'));
+
+      // The externally created signal should NOT be disposed (it's not local)
+      // Only locally created signals should be disposed
+      expect(disposed, isFalse);
+    });
+
+    testNocterm('should dispose locally created signals on unmount', (tester) async {
+      await tester.pumpComponent(const _TestLocalSignal());
+
+      // Replace with a different component to unmount
+      await tester.pumpComponent(const Text('Replaced'));
+      await tester.pump();
+
+      // Test passes if no errors occur during dispose
+    });
   });
 
   group('Watch', () {
@@ -42,13 +70,62 @@ void main() {
 
       expect(tester.terminalState, containsText('Count: 10'));
     });
+
+    testNocterm('Watch.builder should work the same as Watch', (tester) async {
+      final count = signal(0);
+
+      await tester.pumpComponent(_TestWatchBuilder2(count: count));
+
+      expect(tester.terminalState, containsText('Count: 0'));
+
+      count.value = 42;
+      await tester.pump();
+
+      expect(tester.terminalState, containsText('Count: 42'));
+    });
+
+    testNocterm('should support dependencies parameter', (tester) async {
+      final dep = signal(0);
+      final count = signal(0);
+
+      await tester.pumpComponent(_TestWatchWithDeps(count: count, dep: dep));
+
+      expect(tester.terminalState, containsText('Count: 0, Dep: 0'));
+
+      dep.value = 5;
+      await tester.pump();
+
+      expect(tester.terminalState, containsText('Count: 0, Dep: 5'));
+    });
+
+    testNocterm('nested Watch components should work', (tester) async {
+      final outer = signal(0);
+      final inner = signal(100);
+
+      await tester.pumpComponent(_TestNestedWatch(outer: outer, inner: inner));
+
+      expect(tester.terminalState, containsText('Outer: 0'));
+      expect(tester.terminalState, containsText('Inner: 100'));
+
+      outer.value = 1;
+      await tester.pump();
+
+      expect(tester.terminalState, containsText('Outer: 1'));
+      expect(tester.terminalState, containsText('Inner: 100'));
+
+      inner.value = 200;
+      await tester.pump();
+
+      expect(tester.terminalState, containsText('Outer: 1'));
+      expect(tester.terminalState, containsText('Inner: 200'));
+    });
   });
 
   group('WatchBuilder', () {
     testNocterm('should rebuild when signal changes', (tester) async {
       final count = signal(0);
 
-      await tester.pumpComponent(_TestWatchBuilder(count: count));
+      await tester.pumpComponent(_TestWatchBuilderNew(count: count));
 
       expect(tester.terminalState, containsText('Value: 0'));
 
@@ -56,6 +133,21 @@ void main() {
       await tester.pump();
 
       expect(tester.terminalState, containsText('Value: 42'));
+    });
+
+    testNocterm('should pass child to builder', (tester) async {
+      final count = signal(0);
+
+      await tester.pumpComponent(_TestWatchBuilderWithChild(count: count));
+
+      expect(tester.terminalState, containsText('Value: 0'));
+      expect(tester.terminalState, containsText('Static Child'));
+
+      count.value = 10;
+      await tester.pump();
+
+      expect(tester.terminalState, containsText('Value: 10'));
+      expect(tester.terminalState, containsText('Static Child'));
     });
   });
 
@@ -72,8 +164,73 @@ void main() {
 
       expect(tester.terminalState, containsText('Count: 7'));
     });
+
+    testNocterm('watch/unwatch/watch cycle should work', (tester) async {
+      final count = signal(0);
+
+      await tester.pumpComponent(_TestWatchUnwatchWatch(count: count));
+
+      expect(tester.terminalState, containsText('Count: 0'));
+
+      // First change should trigger rebuild
+      count.value = 1;
+      await tester.pump();
+      expect(tester.terminalState, containsText('Count: 1'));
+    });
+  });
+
+  group('Edge Cases', () {
+    testNocterm('rapid signal updates should not cause issues', (tester) async {
+      final count = signal(0);
+
+      await tester.pumpComponent(_TestWatch(count: count));
+
+      // Rapid updates
+      for (var i = 0; i < 100; i++) {
+        count.value = i;
+      }
+      await tester.pump();
+
+      expect(tester.terminalState, containsText('Count: 99'));
+    });
+
+    testNocterm('multiple signals should all trigger rebuilds', (tester) async {
+      final a = signal(0);
+      final b = signal(0);
+
+      await tester.pumpComponent(_TestMultipleSignals(a: a, b: b));
+
+      expect(tester.terminalState, containsText('A: 0, B: 0'));
+
+      a.value = 1;
+      await tester.pump();
+      expect(tester.terminalState, containsText('A: 1, B: 0'));
+
+      b.value = 2;
+      await tester.pump();
+      expect(tester.terminalState, containsText('A: 1, B: 2'));
+    });
+
+    testNocterm('effects should run when dependencies change', (tester) async {
+      var effectRan = 0;
+
+      await tester.pumpComponent(_TestEffect(
+        onEffect: () => effectRan++,
+      ));
+
+      // Effect runs on init
+      expect(effectRan, equals(1));
+
+      // Trigger rebuild by sending a key
+      await tester.sendKey(LogicalKey.space);
+
+      // Effect should run again
+      expect(effectRan, equals(2));
+    });
   });
 }
+
+// Test Components
 
 class _TestCounter extends StatefulComponent {
   const _TestCounter({required this.count});
@@ -125,6 +282,22 @@ class _TestComputedCounterState extends State<_TestComputedCounter>
   }
 }
 
+class _TestLocalSignal extends StatefulComponent {
+  const _TestLocalSignal();
+
+  @override
+  State<_TestLocalSignal> createState() => _TestLocalSignalState();
+}
+
+class _TestLocalSignalState extends State<_TestLocalSignal> with SignalsMixin {
+  late final _count = createSignal(0);
+
+  @override
+  Component build(BuildContext context) {
+    return Text('Count: ${_count()}');
+  }
+}
+
 class _TestWatch extends StatelessComponent {
   const _TestWatch({required this.count});
 
@@ -136,16 +309,79 @@ class _TestWatch extends StatelessComponent {
   }
 }
 
-class _TestWatchBuilder extends StatelessComponent {
-  const _TestWatchBuilder({required this.count});
+class _TestWatchBuilder2 extends StatelessComponent {
+  const _TestWatchBuilder2({required this.count});
 
   final Signal<int> count;
 
   @override
   Component build(BuildContext context) {
-    return WatchBuilder<int>(
-      signal: count,
-      builder: (context, value, child) => Text('Value: $value'),
+    return Watch.builder(
+      builder: (context) => Text('Count: ${count()}'),
+    );
+  }
+}
+
+class _TestWatchWithDeps extends StatelessComponent {
+  const _TestWatchWithDeps({required this.count, required this.dep});
+
+  final Signal<int> count;
+  final Signal<int> dep;
+
+  @override
+  Component build(BuildContext context) {
+    return Watch(
+      (context) => Text('Count: ${count()}, Dep: ${dep()}'),
+      dependencies: [dep],
+    );
+  }
+}
+
+class _TestNestedWatch extends StatelessComponent {
+  const _TestNestedWatch({required this.outer, required this.inner});
+
+  final Signal<int> outer;
+  final Signal<int> inner;
+
+  @override
+  Component build(BuildContext context) {
+    return Watch((context) => Column(
+      children: [
+        Text('Outer: ${outer()}'),
+        Watch((context) => Text('Inner: ${inner()}')),
+      ],
+    ));
+  }
+}
+
+class _TestWatchBuilderNew extends StatelessComponent {
+  const _TestWatchBuilderNew({required this.count});
+
+  final Signal<int> count;
+
+  @override
+  Component build(BuildContext context) {
+    return WatchBuilder(
+      builder: (context, child) => Text('Value: ${count()}'),
+    );
+  }
+}
+
+class _TestWatchBuilderWithChild extends StatelessComponent {
+  const _TestWatchBuilderWithChild({required this.count});
+
+  final Signal<int> count;
+
+  @override
+  Component build(BuildContext context) {
+    return WatchBuilder(
+      child: const Text('Static Child'),
+      builder: (context, child) => Column(
+        children: [
+          Text('Value: ${count()}'),
+          if (child != null) child,
+        ],
+      ),
     );
   }
 }
@@ -159,5 +395,79 @@ class _TestWatchSignal extends StatelessComponent {
   Component build(BuildContext context) {
     final value = count.watch(context);
     return Text('Count: $value');
+  }
+}
+
+class _TestWatchUnwatchWatch extends StatefulComponent {
+  const _TestWatchUnwatchWatch({required this.count});
+
+  final Signal<int> count;
+
+  @override
+  State<_TestWatchUnwatchWatch> createState() => _TestWatchUnwatchWatchState();
+}
+
+class _TestWatchUnwatchWatchState extends State<_TestWatchUnwatchWatch> with SignalsMixin {
+  @override
+  void initState() {
+    super.initState();
+    // Watch, unwatch, then watch again
+    bindSignal(component.count);
+    unbindSignal(component.count);
+    bindSignal(component.count);
+  }
+
+  @override
+  Component build(BuildContext context) {
+    return Text('Count: ${component.count.value}');
+  }
+}
+
+class _TestMultipleSignals extends StatelessComponent {
+  const _TestMultipleSignals({required this.a, required this.b});
+
+  final Signal<int> a;
+  final Signal<int> b;
+
+  @override
+  Component build(BuildContext context) {
+    return Watch((context) => Text('A: ${a()}, B: ${b()}'));
+  }
+}
+
+class _TestEffect extends StatefulComponent {
+  const _TestEffect({required this.onEffect});
+
+  final void Function() onEffect;
+
+  @override
+  State<_TestEffect> createState() => _TestEffectState();
+}
+
+class _TestEffectState extends State<_TestEffect> with SignalsMixin {
+  late final _count = createSignal(0);
+
+  @override
+  void initState() {
+    super.initState();
+    createEffect(() {
+      _count(); // Track dependency
+      component.onEffect();
+    });
+  }
+
+  @override
+  Component build(BuildContext context) {
+    return Focusable(
+      focused: true,
+      onKeyEvent: (event) {
+        if (event.logicalKey == LogicalKey.space) {
+          _count.value++;
+          return true;
+        }
+        return false;
+      },
+      child: Text('Count: ${_count()}'),
+    );
   }
 }

--- a/packages/signals_nocterm/test/signals_nocterm_test.dart
+++ b/packages/signals_nocterm/test/signals_nocterm_test.dart
@@ -1,0 +1,163 @@
+import 'package:nocterm/nocterm.dart';
+import 'package:signals_nocterm/signals_nocterm.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('SignalsMixin', () {
+    testNocterm('should rebuild when signal changes', (tester) async {
+      final count = signal(0);
+
+      await tester.pumpComponent(_TestCounter(count: count));
+
+      expect(tester.terminalState, containsText('Count: 0'));
+
+      count.value = 5;
+      await tester.pump();
+
+      expect(tester.terminalState, containsText('Count: 5'));
+    });
+
+    testNocterm('should rebuild when computed changes', (tester) async {
+      await tester.pumpComponent(const _TestComputedCounter());
+
+      expect(tester.terminalState, containsText('Count: 0, Doubled: 0'));
+
+      // Simulate key press to increment
+      await tester.sendKey(LogicalKey.space);
+
+      expect(tester.terminalState, containsText('Count: 1, Doubled: 2'));
+    });
+  });
+
+  group('Watch', () {
+    testNocterm('should rebuild when signal changes', (tester) async {
+      final count = signal(0);
+
+      await tester.pumpComponent(_TestWatch(count: count));
+
+      expect(tester.terminalState, containsText('Count: 0'));
+
+      count.value = 10;
+      await tester.pump();
+
+      expect(tester.terminalState, containsText('Count: 10'));
+    });
+  });
+
+  group('WatchBuilder', () {
+    testNocterm('should rebuild when signal changes', (tester) async {
+      final count = signal(0);
+
+      await tester.pumpComponent(_TestWatchBuilder(count: count));
+
+      expect(tester.terminalState, containsText('Value: 0'));
+
+      count.value = 42;
+      await tester.pump();
+
+      expect(tester.terminalState, containsText('Value: 42'));
+    });
+  });
+
+  group('watchSignal', () {
+    testNocterm('should rebuild when signal changes', (tester) async {
+      final count = signal(0);
+
+      await tester.pumpComponent(_TestWatchSignal(count: count));
+
+      expect(tester.terminalState, containsText('Count: 0'));
+
+      count.value = 7;
+      await tester.pump();
+
+      expect(tester.terminalState, containsText('Count: 7'));
+    });
+  });
+}
+
+class _TestCounter extends StatefulComponent {
+  const _TestCounter({required this.count});
+
+  final Signal<int> count;
+
+  @override
+  State<_TestCounter> createState() => _TestCounterState();
+}
+
+class _TestCounterState extends State<_TestCounter> with SignalsMixin {
+  @override
+  void initState() {
+    super.initState();
+    bindSignal(component.count);
+  }
+
+  @override
+  Component build(BuildContext context) {
+    return Text('Count: ${component.count.value}');
+  }
+}
+
+class _TestComputedCounter extends StatefulComponent {
+  const _TestComputedCounter();
+
+  @override
+  State<_TestComputedCounter> createState() => _TestComputedCounterState();
+}
+
+class _TestComputedCounterState extends State<_TestComputedCounter>
+    with SignalsMixin {
+  late final _count = createSignal(0);
+  late final _doubled = createComputed(() => _count() * 2);
+
+  @override
+  Component build(BuildContext context) {
+    return Focusable(
+      focused: true,
+      onKeyEvent: (event) {
+        if (event.logicalKey == LogicalKey.space) {
+          _count.value++;
+          return true;
+        }
+        return false;
+      },
+      child: Text('Count: ${_count()}, Doubled: ${_doubled()}'),
+    );
+  }
+}
+
+class _TestWatch extends StatelessComponent {
+  const _TestWatch({required this.count});
+
+  final Signal<int> count;
+
+  @override
+  Component build(BuildContext context) {
+    return Watch((context) => Text('Count: ${count()}'));
+  }
+}
+
+class _TestWatchBuilder extends StatelessComponent {
+  const _TestWatchBuilder({required this.count});
+
+  final Signal<int> count;
+
+  @override
+  Component build(BuildContext context) {
+    return WatchBuilder<int>(
+      signal: count,
+      builder: (context, value, child) => Text('Value: $value'),
+    );
+  }
+}
+
+class _TestWatchSignal extends StatelessComponent {
+  const _TestWatchSignal({required this.count});
+
+  final Signal<int> count;
+
+  @override
+  Component build(BuildContext context) {
+    final value = count.watch(context);
+    return Text('Count: $value');
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -33,6 +33,7 @@ workspace:
   - packages/signals_flutter
   - packages/signals_hooks
   - packages/signals_lint
+  - packages/signals_nocterm
 
   - benchmark/frameworks/preact_signals
   - benchmark/frameworks/signals_core


### PR DESCRIPTION
## Summary

This PR adds a new `signals_nocterm` package that integrates the signals reactive state management library with the [Nocterm](https://nocterm.dev) terminal UI framework.

Closes #442

## Features

- **SignalsMixin**: Mixin for `State` classes to automatically manage signal lifecycle (create signals, computed values, and effects that are automatically disposed)
- **Watch**: Component for fine-grained rebuilds when signals change
- **WatchBuilder**: Builder pattern for watching a single signal
- **watchSignal**: Extension and function to watch signals in any build method

## Implementation Details

The implementation follows the same patterns as `signals_flutter` to provide a familiar API for users of both libraries. Key adaptations for Nocterm:

- Uses Nocterm's `SchedulerBinding` instead of Flutter's for frame scheduling
- Uses Nocterm's `Element` and `BuildContext` instead of Flutter's
- Integrates with Nocterm's component lifecycle (`State<T>`, `StatefulComponent`, etc.)

## Example Usage

```dart
class Counter extends StatefulComponent {
  const Counter({super.key});

  @override
  State<Counter> createState() => _CounterState();
}

class _CounterState extends State<Counter> with SignalsMixin {
  late final _count = createSignal(0);
  late final _doubled = createComputed(() => _count() * 2);

  @override
  void initState() {
    super.initState();
    createEffect(() {
      print('Count: ${_count()}, Doubled: ${_doubled()}');
    });
  }

  @override
  Component build(BuildContext context) {
    return Focusable(
      focused: true,
      onKeyEvent: (event) {
        if (event.logicalKey == LogicalKey.space) {
          _count.value++;
          return true;
        }
        return false;
      },
      child: Center(
        child: Text('Count: ${_count()}, Doubled: ${_doubled()}'),
      ),
    );
  }
}
```

## Test plan

- [ ] Run tests with `dart test` in the signals_nocterm package
- [ ] Verify example works with a Nocterm application
- [ ] Check that signals are properly disposed when components unmount

## Notes

This is a draft PR - happy to iterate on the API based on feedback from @rodydavis and the community.