### PR TITLE
fix(signals_core): make AsyncSignal.reload/refresh properly awaitable

### DIFF
--- a/packages/signals_core/lib/src/async/signal.dart
+++ b/packages/signals_core/lib/src/async/signal.dart
@@ -238,20 +238,26 @@ class AsyncSignal<T> extends Signal<AsyncState<T>>
 
   /// Reload the future
   Future<void> reload() async {
-    value = switch (value) {
-      AsyncData<T> data => AsyncDataReloading<T>(data.value),
-      AsyncError<T> err => AsyncErrorReloading<T>(err.error, err.stackTrace),
-      AsyncLoading<T>() => AsyncLoading<T>(),
-    };
+    batch(() {
+      if (completer.isCompleted) completer = Completer<bool>();
+      value = switch (value) {
+        AsyncData<T> data => AsyncDataReloading<T>(data.value),
+        AsyncError<T> err => AsyncErrorReloading<T>(err.error, err.stackTrace),
+        AsyncLoading<T>() => AsyncLoading<T>(),
+      };
+    });
   }
 
   /// Refresh the future
   Future<void> refresh() async {
-    value = switch (value) {
-      AsyncData<T> data => AsyncDataRefreshing<T>(data.value),
-      AsyncError<T> err => AsyncErrorRefreshing<T>(err.error, err.stackTrace),
-      AsyncLoading<T>() => AsyncLoading<T>(),
-    };
+    batch(() {
+      if (completer.isCompleted) completer = Completer<bool>();
+      value = switch (value) {
+        AsyncData<T> data => AsyncDataRefreshing<T>(data.value),
+        AsyncError<T> err => AsyncErrorRefreshing<T>(err.error, err.stackTrace),
+        AsyncLoading<T>() => AsyncLoading<T>(),
+      };
+    });
   }
 
   @override

--- a/packages/signals_core/test/async/future_test.dart
+++ b/packages/signals_core/test/async/future_test.dart
@@ -138,6 +138,44 @@ void main() {
       expect(signal.value.error, null);
     });
 
+    test('reload is awaitable across repeated calls', () async {
+      int calls = 0;
+
+      Future<int> future() async {
+        await Future.delayed(const Duration(milliseconds: 5));
+        return ++calls;
+      }
+
+      final signal = futureSignal(() => future());
+
+      expect(await signal.future, 1);
+
+      await signal.reload();
+      expect(signal.value.value, 2);
+
+      await signal.reload();
+      expect(signal.value.value, 3);
+    });
+
+    test('refresh is awaitable across repeated calls', () async {
+      int calls = 0;
+
+      Future<int> future() async {
+        await Future.delayed(const Duration(milliseconds: 5));
+        return ++calls;
+      }
+
+      final signal = futureSignal(() => future());
+
+      expect(await signal.future, 1);
+
+      await signal.refresh();
+      expect(signal.value.value, 2);
+
+      await signal.refresh();
+      expect(signal.value.value, 3);
+    });
+
     test('dependencies', () async {
       final prefix = signal('a');
       final val = signal(0);


### PR DESCRIPTION
`AsyncSignal.reload()` and `AsyncSignal.refresh()` flip the value to the *Reloading / *Refreshing variant but never reset the internal `completer`. After the first completion, the completer stays completed, so `await future` (and by extension `await futureSignal.reload()` / `await futureSignal.refresh()` — which both end with `await future`) resolves immediately with stale data on every subsequent call.

This is inconsistent with the rest of `AsyncSignal`: `setError`, `setValue`, `setLoading`, and `reset` all reset the completer when mutating state. `reload` and `refresh` are the outliers.

Fix: wrap the state mutation in `batch(() { ... })` matching the existing pattern in `setError` / `setValue` / `reset`, and reset the completer if it was already completed before flipping state.

Regression tests added that fail without the fix (returned value stays stale at 1 instead of advancing to 2 after `await reload()` / `await refresh()`).