### PR TITLE
fix(signals_core): make StreamSignal.reset re-evaluate lazily on next read

### DIFF
--- a/packages/signals_core/lib/src/async/stream.dart
+++ b/packages/signals_core/lib/src/async/stream.dart
@@ -231,23 +231,27 @@ class StreamSignal<T> extends AsyncSignal<T> {
     bool lazy = true,
     super.autoDispose,
   })  : _onDone = onDone,
-        _stream = computed(
-          () {
-            for (final dep in dependencies) {
-              dep.value;
-            }
-            return fn();
-          },
-        ),
         super(
           initialValue != null
               ? AsyncState.data(initialValue)
               : AsyncState.loading(),
         ) {
+    _stream = computed(
+      () {
+        _resetTrigger.value;
+        for (final dep in dependencies) {
+          dep.value;
+        }
+        return fn();
+      },
+    );
     if (!lazy) value;
   }
 
-  final Computed<Stream<T>> _stream;
+  late final Computed<Stream<T>> _stream;
+
+  /// Bumped by [reset] to mark [_stream] as outdated for lazy re-evaluation.
+  final Signal<int> _resetTrigger = signal(0);
   bool _fetching = false;
   StreamSubscription<T>? _subscription;
   final void Function()? _onDone;
@@ -330,14 +334,40 @@ class StreamSignal<T> extends AsyncSignal<T> {
     await execute(_stream.value);
   }
 
+  /// Mark the signal for re-evaluation on the next read of `.value`.
+  ///
+  /// Preserves the previous value/error with a refreshing flag.
   @override
   void reset([AsyncState<T>? value]) {
-    super.reset(value);
-    _fetching = false;
-    _done = false;
+    _cleanup?.call();
+    _cleanup = null;
     _subscription?.cancel();
     _subscription = null;
-    init();
+    _fetching = false;
+    _done = false;
+    super.reset(value ?? _refreshingValueFor(super.value));
+    _resetTrigger.value++;
+  }
+
+  void _onUpstreamStreamChanged(Stream<T> src) {
+    _subscription?.cancel();
+    _subscription = null;
+    _fetching = false;
+    _done = false;
+    batch(() {
+      value = _refreshingValueFor(super.value);
+      if (completer.isCompleted) completer = Completer<bool>();
+    });
+    execute(src);
+  }
+
+  AsyncState<T> _refreshingValueFor(AsyncState<T> current) {
+    return switch (current) {
+      AsyncData<T> data => AsyncDataRefreshing<T>(data.value),
+      AsyncError<T> err =>
+        AsyncErrorRefreshing<T>(err.error, err.stackTrace),
+      AsyncLoading<T>() => AsyncLoading<T>(),
+    };
   }
 
   @override
@@ -349,10 +379,7 @@ class StreamSignal<T> extends AsyncSignal<T> {
 
   @override
   AsyncState<T> get value {
-    _cleanup ??= _stream.subscribe((src) {
-      reset();
-      execute(src);
-    });
+    _cleanup ??= _stream.subscribe(_onUpstreamStreamChanged);
     return super.value;
   }
 

--- a/packages/signals_core/test/async/future_test.dart
+++ b/packages/signals_core/test/async/future_test.dart
@@ -138,6 +138,49 @@ void main() {
       expect(signal.value.error, null);
     });
 
+    test('reset preserves previous data with refreshing flag', () async {
+      Future<int> future() async {
+        await Future.delayed(const Duration(milliseconds: 5));
+        return 10;
+      }
+
+      final signal = futureSignal(() => future());
+
+      await signal.future;
+      expect(signal.value, isA<AsyncData<int>>());
+      expect(signal.value.value, 10);
+
+      signal.reset();
+
+      expect(signal.peek(), isA<AsyncDataRefreshing<int>>());
+      expect(signal.peek().value, 10);
+      expect(signal.peek().isLoading, true);
+      expect(signal.peek().hasValue, true);
+    });
+
+    test('reset is lazy: does not re-run future until next read', () async {
+      int calls = 0;
+
+      Future<int> future() async {
+        calls++;
+        await Future.delayed(const Duration(milliseconds: 5));
+        return calls;
+      }
+
+      final signal = futureSignal(() => future());
+
+      await signal.future;
+      expect(calls, 1);
+
+      signal.reset();
+      expect(calls, 1);
+
+      final result = await signal.future;
+      expect(calls, 2);
+      expect(result, 2);
+      expect(signal.value.value, 2);
+    });
+
     test('dependencies', () async {
       final prefix = signal('a');
       final val = signal(0);


### PR DESCRIPTION
## Problem

`StreamSignal.reset()` (inherited by `FutureSignal`) cancels the in-flight subscription but leaves `_cleanup` populated. Because the `value` getter guards with `_cleanup ??= _stream.subscribe(...)`, no re-subscription ever happens after reset — the signal gets stuck until manual `reload()` / `refresh()` (both eager).

```dart
final s = futureSignal(() => fetchUser());
await s.future;     // OK
s.reset();
await s.future;     // hangs forever
```

## Fix

`reset()` is now a proper lazy invalidation:

- Preserves previous value/error as `AsyncDataRefreshing` / `AsyncErrorRefreshing`.
- Resets the internal completer so `await signal.future` waits for the new value.
- Does **not** invoke `fn` at reset time — runs on the next `.value` read. Active watchers refetch immediately; unobserved signals stay idle.

Same semantics as Riverpod's `ref.invalidate`.

## Implementation

`_resetTrigger` (`Signal<int>`) is added as a synthetic dependency of `_stream`. Bumping it in `reset()` is the smallest source-version change that the engine can observe, which makes the cached stream outdated without eagerly running `fn`.

The subscribe callback is moved to `_onUpstreamStreamChanged` so it no longer needs to call `reset()` (which would now tear down `_cleanup` from inside itself).

## Tests

Two regression tests in `future_test.dart`. RED confirmed on unfixed code; GREEN with fix; full suite (695 tests) passes.